### PR TITLE
Prevent buffer overrun

### DIFF
--- a/src/shearwater_predator_parser.c
+++ b/src/shearwater_predator_parser.c
@@ -214,7 +214,7 @@ shearwater_predator_parser_get_datetime (dc_parser_t *abstract, dc_datetime_t *d
 }
 
 
-#define BUFLEN 16
+#define BUFLEN 32
 
 static dc_status_t
 shearwater_predator_parser_cache (shearwater_predator_parser_t *parser)


### PR DESCRIPTION
When compiled with older Microsoft libraries, the unsafe implemention of
snprintf results in non-null terminated strings, causing numerous subsequent
issues. This fix just enlarges the used buffer to accommdate longer strings.
A more complete solution would include the use more recent Microsoft libraries in
the build process. The larger buffer is still need then, to prevent trucated
(but proper null terminated) strings.

ref: https://github.com/Subsurface-divelog/subsurface/issues/301

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>