### PR TITLE
Create ne w"custom_io" packet sending model 

### DIFF
--- a/include/libdivecomputer/Makefile.am
+++ b/include/libdivecomputer/Makefile.am
@@ -3,7 +3,7 @@ libdivecomputer_HEADERS = 	\
 	version.h \
 	common.h \
 	context.h \
-	custom_serial.h \
+	custom_io.h \
 	buffer.h \
 	descriptor.h \
 	iterator.h \

--- a/include/libdivecomputer/context.h
+++ b/include/libdivecomputer/context.h
@@ -23,7 +23,7 @@
 #define DC_CONTEXT_H
 
 #include "common.h"
-#include "custom_serial.h"
+#include "custom_io.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,7 +49,7 @@ dc_status_t
 dc_context_free (dc_context_t *context);
 
 dc_status_t
-dc_context_set_custom_serial (dc_context_t *context, dc_custom_serial_t *custom_serial);
+dc_context_set_custom_io (dc_context_t *context, dc_custom_io_t *custom_io);
 
 dc_status_t
 dc_context_set_loglevel (dc_context_t *context, dc_loglevel_t loglevel);

--- a/include/libdivecomputer/custom_io.h
+++ b/include/libdivecomputer/custom_io.h
@@ -1,5 +1,5 @@
-#ifndef CUSTOM_SERIAL_H
-#define CUSTOM_SERIAL_H
+#ifndef CUSTOM_IO_H
+#define CUSTOM_IO_H
 
 #include "common.h"
 
@@ -62,29 +62,40 @@ typedef enum dc_line_t {
 
 #endif /* __SERIAL_TYPES__ */
 
-typedef struct dc_custom_serial_t
+struct dc_context_t;
+
+typedef struct dc_custom_io_t
 {
 	void *userdata;
-	dc_status_t (*open) (void **userdata, const char *name);
-	dc_status_t (*close) (void **userdata);
-	dc_status_t (*read) (void **userdata, void* data, size_t size, size_t *actual);
-	dc_status_t (*write) (void **userdata, const void* data, size_t size, size_t *actual);
-	dc_status_t (*purge) (void **userdata, dc_direction_t);
-	dc_status_t (*get_available) (void **userdata, size_t *value);
-	dc_status_t (*set_timeout) (void **userdata, long timeout);
-	dc_status_t (*configure) (void **userdata, unsigned int baudrate, unsigned int databits, dc_parity_t parity, dc_stopbits_t stopbits, dc_flowcontrol_t flowcontrol);
-	dc_status_t (*set_dtr) (void **userdata, int level);
-	dc_status_t (*set_rts) (void **userdata, int level);
-	dc_status_t (*set_halfduplex) (void **userdata, unsigned int value);
-	dc_status_t (*set_break) (void **userdata, unsigned int level);
+
+	// Custom serial (generally BT rfcomm)
+	dc_status_t (*serial_open) (void **userdata, const char *name);
+	dc_status_t (*serial_close) (void **userdata);
+	dc_status_t (*serial_read) (void **userdata, void* data, size_t size, size_t *actual);
+	dc_status_t (*serial_write) (void **userdata, const void* data, size_t size, size_t *actual);
+	dc_status_t (*serial_purge) (void **userdata, dc_direction_t);
+	dc_status_t (*serial_get_available) (void **userdata, size_t *value);
+	dc_status_t (*serial_set_timeout) (void **userdata, long timeout);
+	dc_status_t (*serial_configure) (void **userdata, unsigned int baudrate, unsigned int databits, dc_parity_t parity, dc_stopbits_t stopbits, dc_flowcontrol_t flowcontrol);
+	dc_status_t (*serial_set_dtr) (void **userdata, int level);
+	dc_status_t (*serial_set_rts) (void **userdata, int level);
+	dc_status_t (*serial_set_halfduplex) (void **userdata, unsigned int value);
+	dc_status_t (*serial_set_break) (void **userdata, unsigned int level);
 	//dc_serial_set_latency (dc_serial_t *device, unsigned int milliseconds) - Unused
 	//dc_serial_get_lines (dc_serial_t *device, unsigned int *value) - Unused
 	//dc_serial_flush (dc_serial_t *device) - No device interaction
 	//dc_serial_sleep (dc_serial_t *device, unsigned int timeout) - No device interaction
-} dc_custom_serial_t;
+
+	// Custom packet transfer (generally BLE GATT)
+	int packet_size;
+	dc_status_t (*packet_open) (struct dc_custom_io_t *, struct dc_context_t *, const char *);
+	dc_status_t (*packet_close) (struct dc_custom_io_t *);
+	dc_status_t (*packet_read) (struct dc_custom_io_t *, void* data, size_t size, size_t *actual);
+	dc_status_t (*packet_write) (struct dc_custom_io_t *, const void* data, size_t size, size_t *actual);
+} dc_custom_io_t;
 
 
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-#endif /* CUSTOM_SERIAL_H */
+#endif /* CUSTOM_IO_H */

--- a/include/libdivecomputer/version.h.in
+++ b/include/libdivecomputer/version.h.in
@@ -28,7 +28,7 @@ extern "C" {
 
 /* use these defines to detect Subsurface specific features */
 #define SSRF_LIBDC_VERSION 1
-#define SSRF_CUSTOM_SERIAL 1
+#define SSRF_CUSTOM_IO 1
 
 #define DC_VERSION "@DC_VERSION@"
 #define DC_VERSION_MAJOR @DC_VERSION_MAJOR@

--- a/src/context-private.h
+++ b/src/context-private.h
@@ -27,7 +27,7 @@
 #endif
 
 #include <libdivecomputer/context.h>
-#include <libdivecomputer/custom_serial.h>
+#include <libdivecomputer/custom_io.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -72,16 +72,16 @@ dc_context_syserror (dc_context_t *context, dc_loglevel_t loglevel, const char *
 dc_status_t
 dc_context_hexdump (dc_context_t *context, dc_loglevel_t loglevel, const char *file, unsigned int line, const char *function, const char *prefix, const unsigned char data[], unsigned int size);
 
-dc_custom_serial_t*
-_dc_context_custom_serial (dc_context_t *context);
+dc_custom_io_t*
+_dc_context_custom_io (dc_context_t *context);
 
 #define RETURN_IF_CUSTOM_SERIAL(context, block, function, ...)	\
 	do { \
-		dc_custom_serial_t *c = _dc_context_custom_serial(context); \
+		dc_custom_io_t *c = _dc_context_custom_io(context); \
 		dc_status_t _rc; \
 		if (c) { \
-			if (c->function) \
-				_rc = c->function(&c->userdata, ##__VA_ARGS__); \
+			if (c->serial_##function) \
+				_rc = c->serial_##function(&c->userdata, ##__VA_ARGS__); \
 			else \
 				_rc = DC_STATUS_SUCCESS; \
 			block ;\

--- a/src/context.c
+++ b/src/context.c
@@ -32,7 +32,7 @@
 #endif
 
 #include "context-private.h"
-#include <libdivecomputer/custom_serial.h>
+#include <libdivecomputer/custom_io.h>
 
 struct dc_context_t {
 	dc_loglevel_t loglevel;
@@ -46,7 +46,7 @@ struct dc_context_t {
 	struct timeval timestamp;
 #endif
 #endif
-	dc_custom_serial_t *custom_serial;
+	dc_custom_io_t *custom_io;
 };
 
 #ifdef ENABLE_LOGGING
@@ -197,7 +197,7 @@ dc_context_new (dc_context_t **out)
 #endif
 #endif
 
-	context->custom_serial = NULL;
+	context->custom_io = NULL;
 
 	*out = context;
 
@@ -213,20 +213,20 @@ dc_context_free (dc_context_t *context)
 }
 
 dc_status_t
-dc_context_set_custom_serial (dc_context_t *context, dc_custom_serial_t *custom_serial)
+dc_context_set_custom_io (dc_context_t *context, dc_custom_io_t *custom_io)
 {
 	if (context == NULL)
 		return DC_STATUS_INVALIDARGS;
 
-	context->custom_serial = custom_serial;
+	context->custom_io = custom_io;
 
 	return DC_STATUS_SUCCESS;
 }
 
-dc_custom_serial_t*
-_dc_context_custom_serial (dc_context_t *context)
+dc_custom_io_t*
+_dc_context_custom_io (dc_context_t *context)
 {
-	return context->custom_serial;
+	return context->custom_io;
 }
 
 dc_status_t

--- a/src/device.c
+++ b/src/device.c
@@ -125,10 +125,10 @@ dc_device_open (dc_device_t **out, dc_context_t *context, dc_descriptor_t *descr
 		rc = suunto_d9_device_open (&device, context, name, dc_descriptor_get_model (descriptor));
 		break;
 	case DC_FAMILY_SUUNTO_EONSTEEL:
-		rc = suunto_eonsteel_device_open (&device, context);
+		rc = suunto_eonsteel_device_open (&device, context, name);
 		break;
 	case DC_FAMILY_SCUBAPRO_G2:
-		rc = scubapro_g2_device_open (&device, context);
+		rc = scubapro_g2_device_open (&device, context, name);
 		break;
 	case DC_FAMILY_UWATEC_ALADIN:
 		rc = uwatec_aladin_device_open (&device, context, name);

--- a/src/libdivecomputer.symbols
+++ b/src/libdivecomputer.symbols
@@ -21,7 +21,7 @@ dc_context_new
 dc_context_free
 dc_context_set_loglevel
 dc_context_set_logfunc
-dc_context_set_custom_serial
+dc_context_set_custom_io
 
 dc_iterator_next
 dc_iterator_free

--- a/src/scubapro_g2.h
+++ b/src/scubapro_g2.h
@@ -31,7 +31,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 dc_status_t
-scubapro_g2_device_open (dc_device_t **device, dc_context_t *context);
+scubapro_g2_device_open (dc_device_t **device, dc_context_t *context, const char *name);
 
 #ifdef __cplusplus
 }

--- a/src/suunto_eonsteel.h
+++ b/src/suunto_eonsteel.h
@@ -31,7 +31,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 dc_status_t
-suunto_eonsteel_device_open(dc_device_t **device, dc_context_t *context);
+suunto_eonsteel_device_open(dc_device_t **device, dc_context_t *context, const char *name);
 
 dc_status_t
 suunto_eonsteel_parser_create(dc_parser_t **parser, dc_context_t *context, unsigned int model);

--- a/src/usbhid.h
+++ b/src/usbhid.h
@@ -116,6 +116,10 @@ dc_usbhid_read (dc_usbhid_t *usbhid, void *data, size_t size, size_t *actual);
 dc_status_t
 dc_usbhid_write (dc_usbhid_t *usbhid, const void *data, size_t size, size_t *actual);
 
+/* Create a dc_custom_io_t that uses usbhid for packet transfer */
+dc_status_t
+dc_usbhid_custom_io(dc_context_t *context, unsigned int vid, unsigned int pid);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */


### PR DESCRIPTION
This creates a new "custom_io" model that can be used to send and receive "packets" over some transport, currently only USBHID.

It also converts the two USBHID backends (Suunto EON Steel and Scubapro G2) to use that custom IO model.

The plan is to be able to then replace the USBHID transport with a BLE GATT-based transport fairly transparently to the libdivecomputer backends (I say "fairly", because the packetization is going to be exposed, and each dive computer backend will inevitably see some transport specifics because they have their own logic of how to encode the stream over the packet interface).