### PR TITLE
build: ignore the build from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ Makefile.in
 /src/libdivecomputer.la
 /src/libdivecomputer.rc
 /src/revision.h
+
+/build


### PR DESCRIPTION
Now as a submodule, the change in libdivecomputer created by the build process is annoying. Just ignore it.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>