### PR TITLE
Add G2 HUD to udev rules file.

### DIFF
--- a/contrib/udev/libdivecomputer.rules
+++ b/contrib/udev/libdivecomputer.rules
@@ -13,5 +13,8 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="2e6c", ATTR{idProduct}=="3201", GROUP="plugde
 # Scubapro G2 Console
 SUBSYSTEM=="usb", ATTR{idVendor}=="2e6c", ATTR{idProduct}=="3211", GROUP="plugdev"
 
+# Scubapro G2 HUD
+SUBSYSTEM=="usb", ATTR{idVendor}=="2e6c", ATTR{idProduct}=="4201", GROUP="plugdev"
+
 # Scubapro Aladin Square
 SUBSYSTEM=="usb", ATTR{idVendor}=="c251", ATTR{idProduct}=="2006", GROUP="plugdev"


### PR DESCRIPTION
Simply adds the G2 HUD to the udev rules in contrib folder.

Signed-Off-By: William M Perry <wmperry@gmail.com>