### PR TITLE
fix some coverity errors

### DIFF
--- a/src/deepblu.c
+++ b/src/deepblu.c
@@ -451,7 +451,7 @@ deepblu_download_dive(deepblu_device_t *device, unsigned char nr, dc_dive_callba
 		if (!callback(profile, profile_len+256, header, header_len, userdata))
 			return DC_STATUS_DONE;
 	}
-
+	free(profile);
 	return DC_STATUS_SUCCESS;
 }
 

--- a/src/garmin.c
+++ b/src/garmin.c
@@ -169,6 +169,7 @@ static int get_file_list(dc_device_t *abstract, DIR *dir, struct file_list *file
 		 */
 		entry = files->array + files->nr++;
 		strncpy(entry->name, de->d_name, FIT_NAME_SIZE);
+		entry->name[FIT_NAME_SIZE] = 0; // ensure it's null-terminated
 	}
 	DEBUG (abstract->context, "Found %d files", files->nr);
 
@@ -334,5 +335,6 @@ garmin_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, void 
 
 	free(files.array);
 	dc_parser_destroy(parser);
+	dc_buffer_free(file);
 	return status;
 }

--- a/src/garmin.h
+++ b/src/garmin.h
@@ -50,7 +50,7 @@ garmin_parser_is_dive (dc_parser_t *abstract, const unsigned char *data, unsigne
 #define FIT_NAME_SIZE 24
 
 struct fit_name {
-	char name[FIT_NAME_SIZE];
+	char name[FIT_NAME_SIZE + 1];
 };
 
 #ifdef __cplusplus

--- a/src/oceans_s1.c
+++ b/src/oceans_s1.c
@@ -210,8 +210,10 @@ static dc_status_t oceans_s1_get_blob(oceans_s1_device_t *s1, const unsigned cha
 
 	// Tell the Oceans S1 to exit block mode (??)
 	status = dc_iostream_write(s1->iostream, "\006", 1, NULL);
-	if (status != DC_STATUS_SUCCESS)
+	if (status != DC_STATUS_SUCCESS) {
+		dc_buffer_free(res);
 		return status;
+	}
 
 	size = dc_buffer_get_size(res);
 


### PR DESCRIPTION
CID 350142: Resource leak
CID 350154: Resource leak
CID 360641: Resource leak
CID 350147: Possibly not null-terminated strings

One other buffer overrun issue was just fixed by Jef upstream and might be worth merging as well.