### PR TITLE
Garmin Descent Mk2/Mk2i MTP support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,19 @@ AS_IF([test "x$with_libusb" != "xno"], [
 	])
 ])
 
+# Checks for MTP support.
+AC_ARG_WITH([libmtp],
+	[AS_HELP_STRING([--without-libmtp],
+		[Build without the libmtp library])],
+	[], [with_libmtp=auto])
+AS_IF([test "x$with_libmtp" != "xno"], [
+	PKG_CHECK_MODULES([LIBMTP], [libmtp], [have_libmtp=yes], [have_libmtp=no])
+	AS_IF([test "x$have_libmtp" = "xyes"], [
+		AC_DEFINE([HAVE_LIBMTP], [1], [libmtp library])
+		DEPENDENCIES="$DEPENDENCIES libmtp"
+	])
+])
+
 # Checks for HIDAPI support.
 AC_ARG_WITH([hidapi],
 	[AS_HELP_STRING([--without-hidapi],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,9 +1,9 @@
 AM_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
-AM_CFLAGS = $(LIBUSB_CFLAGS) $(HIDAPI_CFLAGS) $(BLUEZ_CFLAGS)
+AM_CFLAGS = $(LIBUSB_CFLAGS) $(LIBMTP_CFLAGS) $(HIDAPI_CFLAGS) $(BLUEZ_CFLAGS)
 
 lib_LTLIBRARIES = libdivecomputer.la
 
-libdivecomputer_la_LIBADD = $(LIBUSB_LIBS) $(HIDAPI_LIBS) $(BLUEZ_LIBS) -lm
+libdivecomputer_la_LIBADD = $(LIBUSB_LIBS) $(LIBMTP_LIBS) $(HIDAPI_LIBS) $(BLUEZ_LIBS) -lm
 libdivecomputer_la_LDFLAGS = \
 	-version-info $(DC_VERSION_LIBTOOL) \
 	-no-undefined \

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -406,8 +406,10 @@ static const dc_descriptor_t g_descriptors[] = {
 	{"Liquivision", "Kaon", DC_FAMILY_LIQUIVISION_LYNX, 3, DC_TRANSPORT_SERIAL, NULL},
 
 	// Not merged upstream yet
-	/* Garmin */
+	/* Garmin -- model numbers as defined in FIT format; USB product id is (0x4000 | model) */
+	/* for the Mk2 we are using the model of the global model - the APAC model is 3702 */
 	{"Garmin", "Descent Mk1", DC_FAMILY_GARMIN, 2859, DC_TRANSPORT_USBSTORAGE, dc_filter_garmin},
+	{"Garmin", "Descent Mk2/Mk2i", DC_FAMILY_GARMIN, 3258, DC_TRANSPORT_USBSTORAGE, dc_filter_garmin},
 	/* Deepblu */
 	{"Deepblu", "Cosmiq+", DC_FAMILY_DEEPBLU, 0, DC_TRANSPORT_BLE, dc_filter_deepblu},
 	/* Oceans S1 */

--- a/src/device.c
+++ b/src/device.c
@@ -229,7 +229,7 @@ dc_device_open (dc_device_t **out, dc_context_t *context, dc_descriptor_t *descr
 
 	// Not merged upstream yet
 	case DC_FAMILY_GARMIN:
-		rc = garmin_device_open (&device, context, iostream);
+		rc = garmin_device_open (&device, context, iostream, dc_descriptor_get_model (descriptor));
 		break;
 	case DC_FAMILY_DEEPBLU:
 		rc = deepblu_device_open (&device, context, iostream);

--- a/src/garmin.c
+++ b/src/garmin.c
@@ -414,6 +414,12 @@ garmin_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, void 
 		return rc;
 	pathname[pathlen] = 0;
 
+#ifdef HAVE_LIBMTP
+	// if the user passes in a path, don't try to read via MTP
+	if (pathlen)
+		device->use_mtp = 0;
+#endif
+
 	// The actual dives are under the "Garmin/Activity/" directory
 	// as FIT files, with names like "2018-08-20-10-23-30.fit".
 	// Make sure our buffer is big enough.

--- a/src/garmin.c
+++ b/src/garmin.c
@@ -58,7 +58,7 @@ static const dc_device_vtable_t garmin_device_vtable = {
 };
 
 dc_status_t
-garmin_device_open (dc_device_t **out, dc_context_t *context, dc_iostream_t *iostream)
+garmin_device_open (dc_device_t **out, dc_context_t *context, dc_iostream_t *iostream, unsigned int model)
 {
 	dc_status_t status = DC_STATUS_SUCCESS;
 	garmin_device_t *device = NULL;

--- a/src/garmin.c
+++ b/src/garmin.c
@@ -124,54 +124,75 @@ static int name_cmp(const void *a, const void *b)
  *
  * Return number of files found.
 */
-static int get_file_list(dc_device_t *abstract, DIR *dir, struct file_list *files)
+
+static int
+check_filename(dc_device_t *abstract, const char *name)
+{
+	int len = strlen(name);
+	const char *explain = NULL;
+
+	DEBUG(abstract->context, "  %s", name);
+
+	if (len < 5)
+		explain = "name too short";
+	if (len >= FIT_NAME_SIZE)
+		explain = "name too long";
+	if (strncasecmp(name + len - 4, ".FIT", 4))
+		explain = "name lacks FIT suffix";
+
+	DEBUG(abstract->context, "  %s - %s", name, explain ? explain : "adding to list");
+	return explain == NULL;
+}
+
+static dc_status_t
+make_space(struct file_list *files)
+{
+	if (files->nr == files->allocated) {
+		struct fit_name *array;
+		int n = 3*(files->allocated + 8)/2;
+		size_t new_size;
+
+		new_size = n * sizeof(array[0]);
+		array = realloc(files->array, new_size);
+		if (!array)
+			return DC_STATUS_NOMEMORY;
+
+		files->array = array;
+		files->allocated = n;
+	}
+	return DC_STATUS_SUCCESS;
+}
+
+static void
+add_name(struct file_list *files, const char *name)
+{
+	/*
+	 * NOTE! This depends on the zero-padding that strncpy does.
+	 *
+	 * strncpy() doesn't just limit the size of the copy, it
+	 * will zero-pad the end of the result buffer.
+	 */
+	struct fit_name *entry = files->array + files->nr++;
+	strncpy(entry->name, name, FIT_NAME_SIZE);
+	entry->name[FIT_NAME_SIZE] = 0; // ensure it's null-terminated
+}
+
+static dc_status_t
+get_file_list(dc_device_t *abstract, DIR *dir, struct file_list *files)
 {
 	struct dirent *de;
 
-	DEBUG (abstract->context, "Iterating over Garmin files");
+	DEBUG(abstract->context, "Iterating over Garmin files");
 	while ((de = readdir(dir)) != NULL) {
-		int len = strlen(de->d_name);
-		struct fit_name *entry;
-		const char *explain = NULL;
-
-		DEBUG (abstract->context, "  %s", de->d_name);
-
-		if (len < 5)
-			explain = "name too short";
-		if (len >= FIT_NAME_SIZE)
-			explain = "name too long";
-		if (strncasecmp(de->d_name + len - 4, ".FIT", 4))
-			explain = "name lacks FIT suffix";
-
-		DEBUG (abstract->context, "  %s - %s", de->d_name, explain ? explain : "adding to list");
-		if (explain)
+		if (!check_filename(abstract, de->d_name))
 			continue;
 
-		if (files->nr == files->allocated) {
-			struct fit_name *array;
-			int n = 3*(files->allocated + 8)/2;
-			size_t new_size;
-
-			new_size = n * sizeof(array[0]);
-			array = realloc(files->array, new_size);
-			if (!array)
-				return DC_STATUS_NOMEMORY;
-
-			files->array = array;
-			files->allocated = n;
-		}
-
-		/*
-		 * NOTE! This depends on the zero-padding that strncpy does.
-		 *
-		 * strncpy() doesn't just limit the size of the copy, it
-		 * will zero-pad the end of the result buffer.
-		 */
-		entry = files->array + files->nr++;
-		strncpy(entry->name, de->d_name, FIT_NAME_SIZE);
-		entry->name[FIT_NAME_SIZE] = 0; // ensure it's null-terminated
+		dc_status_t rc = make_space(files);
+		if (rc != DC_STATUS_SUCCESS)
+			return rc;
+		add_name(files, de->d_name);
 	}
-	DEBUG (abstract->context, "Found %d files", files->nr);
+	DEBUG(abstract->context, "Found %d files", files->nr);
 
 	qsort(files->array, files->nr, sizeof(struct fit_name), name_cmp);
 	return DC_STATUS_SUCCESS;
@@ -221,10 +242,14 @@ garmin_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, void 
 	dc_parser_t *parser;
 	char pathname[PATH_MAX];
 	size_t pathlen;
-	struct file_list files = { 0, 0, NULL };
+	struct file_list files = {
+		0,     // nr
+		0,     // allocated
+		NULL,  // array of names
+	};
 	dc_buffer_t *file;
 	DIR *dir;
-	int rc;
+	dc_status_t rc;
 
 	// Read the directory name from the iostream
 	rc = dc_iostream_read(device->iostream, &pathname, sizeof(pathname)-1, &pathlen);
@@ -239,7 +264,6 @@ garmin_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, void 
 		ERROR (abstract->context, "Invalid Garmin base directory '%s'", pathname);
 		return DC_STATUS_IO;
 	}
-
 	if (pathlen && pathname[pathlen-1] != '/')
 		pathname[pathlen++] = '/';
 	strcpy(pathname + pathlen, "Garmin/Activity");
@@ -268,7 +292,7 @@ garmin_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, void 
 
 		// Found fingerprint, just cut the array short here
 		files.nr = i;
-		DEBUG (abstract->context, "Ignoring '%s' and older", name);
+		DEBUG(abstract->context, "Ignoring '%s' and older", name);
 		break;
 	}
 
@@ -322,7 +346,7 @@ garmin_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, void 
 			devinfo_p = NULL;
 		}
 		if (!is_dive) {
-			DEBUG (abstract->context, "decided %s isn't a dive.", name);
+			DEBUG(abstract->context, "decided %s isn't a dive.", name);
 			continue;
 		}
 

--- a/src/garmin.h
+++ b/src/garmin.h
@@ -49,8 +49,9 @@ garmin_parser_is_dive (dc_parser_t *abstract, const unsigned char *data, unsigne
 // special fixed header in the parser data too.
 #define FIT_NAME_SIZE 24
 
-struct fit_name {
+struct fit_file {
 	char name[FIT_NAME_SIZE + 1];
+	unsigned int mtp_id;
 };
 
 #ifdef __cplusplus

--- a/src/garmin.h
+++ b/src/garmin.h
@@ -32,7 +32,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 dc_status_t
-garmin_device_open (dc_device_t **device, dc_context_t *context, dc_iostream_t *iostream);
+garmin_device_open (dc_device_t **device, dc_context_t *context, dc_iostream_t *iostream, unsigned int model);
 
 dc_status_t
 garmin_parser_create (dc_parser_t **parser, dc_context_t *context);

--- a/src/usb_storage.c
+++ b/src/usb_storage.c
@@ -76,10 +76,14 @@ dc_usb_storage_open (dc_iostream_t **out, dc_context_t *context, const char *nam
 	if (out == NULL || name == NULL)
 		return DC_STATUS_INVALIDARGS;
 
-	INFO (context, "Open: name=%s", name);
-	if (stat(name, &st) < 0 || !S_ISDIR(st.st_mode))
-		return DC_STATUS_NODEVICE;
-
+	if (*name == '\0') {
+		// that indicates an MTP device
+		INFO (context, "Open MTP device");
+	} else {
+		INFO (context, "Open: name=%s", name);
+		if (stat(name, &st) < 0 || !S_ISDIR(st.st_mode))
+			return DC_STATUS_NODEVICE;
+	}
 	// Allocate memory.
 	device = (dc_usbstorage_t *) dc_iostream_allocate (context, &dc_usbstorage_vtable, DC_TRANSPORT_USBSTORAGE);
 	if (device == NULL) {


### PR DESCRIPTION
The Descent Mk2/Mk2i no longer appears as a USB storage / FAT device, but instead as an MTP device.
Instead of adding yet another transport definition, I decided to implement this as two alternative methods of accessing the files directly in `garmin.c`.