### PR TITLE
cleanup: ensure mtp_device field is 0

### DIFF
--- a/src/garmin.c
+++ b/src/garmin.c
@@ -89,7 +89,6 @@ garmin_device_open (dc_device_t **out, dc_context_t *context, dc_iostream_t *ios
 		ERROR (context, "Failed to allocate memory.");
 		return DC_STATUS_NOMEMORY;
 	}
-
 	// Set the default values.
 	device->iostream = iostream;
 	memset(device->fingerprint, 0, sizeof(device->fingerprint));
@@ -99,6 +98,7 @@ garmin_device_open (dc_device_t **out, dc_context_t *context, dc_iostream_t *ios
 	// for Garmin devices, the model number corresponds to the lower three nibbles of the USB product ID
 	// in order to have only one entry for the Mk2, we don't use the Mk2/APAC model number in our code
 	device->use_mtp = (model == (0x0FFF & DESCENT_MK2));
+	device->mtp_device = NULL;
 	DEBUG(context, "Found Garmin with model 0x%x which is a %s\n", model, (device->use_mtp ? "Mk2/Mk2i" : "Mk1"));
 #endif
 


### PR DESCRIPTION
We explicitly check that field for 0 before dereferencing it. Let's make sure
that it always starts out being 0 - otherwise we'll get a potential crash here.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>