### PR TITLE
More serial

### DIFF
--- a/src/mares_iconhd.h
+++ b/src/mares_iconhd.h
@@ -35,7 +35,7 @@ dc_status_t
 mares_iconhd_device_open (dc_device_t **device, dc_context_t *context, dc_iostream_t *iostream);
 
 dc_status_t
-mares_iconhd_parser_create (dc_parser_t **parser, dc_context_t *context, unsigned int model);
+mares_iconhd_parser_create (dc_parser_t **parser, dc_context_t *context, unsigned int model, unsigned int serial);
 
 #ifdef __cplusplus
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -137,7 +137,7 @@ dc_parser_new_internal (dc_parser_t **out, dc_context_t *context, dc_family_t fa
 		rc = mares_darwin_parser_create (&parser, context, model);
 		break;
 	case DC_FAMILY_MARES_ICONHD:
-		rc = mares_iconhd_parser_create (&parser, context, model);
+		rc = mares_iconhd_parser_create (&parser, context, model, serial);
 		break;
 	case DC_FAMILY_HW_OSTC:
 		rc = hw_ostc_parser_create (&parser, context, serial);

--- a/src/parser.c
+++ b/src/parser.c
@@ -92,7 +92,7 @@ dc_parser_new_internal (dc_parser_t **out, dc_context_t *context, dc_family_t fa
 		if (model == 0x01)
 			rc = suunto_eon_parser_create (&parser, context, 1);
 		else
-			rc = suunto_vyper_parser_create (&parser, context);
+			rc = suunto_vyper_parser_create (&parser, context, serial);
 		break;
 	case DC_FAMILY_SUUNTO_VYPER2:
 	case DC_FAMILY_SUUNTO_D9:

--- a/src/suunto_vyper.h
+++ b/src/suunto_vyper.h
@@ -35,7 +35,7 @@ dc_status_t
 suunto_vyper_device_open (dc_device_t **device, dc_context_t *context, dc_iostream_t *iostream);
 
 dc_status_t
-suunto_vyper_parser_create (dc_parser_t **parser, dc_context_t *context);
+suunto_vyper_parser_create (dc_parser_t **parser, dc_context_t *context, unsigned int serial);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
verified the serial data for two dive computer families

I also understand better the serial number situation for the ancient Mares Puck. There only the last four digits of the serial are in the log (so the device will show S#09008022 - but in the download data we only have "8022"). I was torn whether to add this as a string... given how old these dive computers are, I decided not to do it for now.

I also have two different Oceanic dive computers and was hoping to test whether the serial that is parsed in that device code represents what the owner can verify on device - but I appear to have misplaced my Oceanic download cable... I know I had this a few months ago, but it's not where it should be - so I'm submitting the two that I was able to already verify.