### PR TITLE
find lib hidapi on modern openSUSE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,12 @@ AS_IF([test "x$with_hidapi" != "xno"], [
 	AS_IF([test "x$have_hidapi" = "xyes"], [
 		AC_DEFINE([HAVE_HIDAPI], [1], [hidapi library])
 		DEPENDENCIES="$DEPENDENCIES hidapi"
+	], [
+	PKG_CHECK_MODULES([HIDAPI], [hidapi-libusb], [have_hidapi=yes], [have_hidapi=no])
+	AS_IF([test "x$have_hidapi" = "xyes"], [
+		AC_DEFINE([HAVE_HIDAPI], [1], [hidapi library])
+		DEPENDENCIES="$DEPENDENCIES hidapi"
+	])
 	])
 ])
 


### PR DESCRIPTION
There are now two flavors of hidapi and you need to use a different name
to get one.

Autoconf syntax is... insane.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>