### PR TITLE
Garmin: Fix gas change event parsing

### DIFF
--- a/src/garmin_parser.c
+++ b/src/garmin_parser.c
@@ -217,7 +217,7 @@ static void garmin_event(struct garmin_parser_t *garmin,
 		return;
 
 	case 57:
-		sample.gasmix = data - 1;
+		sample.gasmix = data;
 		garmin->callback(DC_SAMPLE_GASMIX, sample, garmin->userdata);
 		return;
 	}


### PR DESCRIPTION
The gas mixes are numbered from 0 and up and the gas change event uses
this number directly, so no need to subtract one.

This is the case for Garmin Mk2i, I don't know if it was different for Mk1. 