### PR TITLE
Garmin: decode divemode

### DIFF
--- a/src/garmin_parser.c
+++ b/src/garmin_parser.c
@@ -564,7 +564,22 @@ DECLARE_FIELD(DEVICE_INFO, firmware, UINT16)
 }
 
 // SPORT
-DECLARE_FIELD(SPORT, sub_sport, ENUM) { garmin->dive.sub_sport = (ENUM) data; }
+DECLARE_FIELD(SPORT, sub_sport, ENUM) {
+	garmin->dive.sub_sport = (ENUM) data;
+	dc_divemode_t val;
+	switch (data) {
+	case 55: val = DC_DIVEMODE_GAUGE;
+		break;
+	case 56:
+	case 57: val = DC_DIVEMODE_FREEDIVE;
+		break;
+	case 63: val = DC_DIVEMODE_CCR;
+		break;
+	default: val = DC_DIVEMODE_OC;
+	}
+	garmin->cache.DIVEMODE = val;
+	garmin->cache.initialized |= 1 << DC_FIELD_DIVEMODE;
+}
 
 // DIVE_GAS - uses msg index
 DECLARE_FIELD(DIVE_GAS, helium, UINT8)
@@ -1502,7 +1517,7 @@ garmin_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigned i
 	case DC_FIELD_ATMOSPHERIC:
 		return DC_STATUS_UNSUPPORTED;
 	case DC_FIELD_DIVEMODE:
-		return DC_STATUS_UNSUPPORTED;
+		return DC_FIELD_VALUE(garmin->cache, value, DIVEMODE);
 	case DC_FIELD_TANK:
 		return DC_STATUS_UNSUPPORTED;
 	case DC_FIELD_STRING:


### PR DESCRIPTION
The code used sub_sport to figure out if this was a dive in the first
place, but then never reported back the specific dive mode, leading to
all dives being interpreted as open circuit.

Reported-By: Anton van Rosmalen
Signed-off-by: Dirk Hohndel <dirk@hohndel.org>