### PR TITLE
Simplistic attempt to support new Aqualung i200C

### DIFF
--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -274,6 +274,7 @@ static const dc_descriptor_t g_descriptors[] = {
 	{"Sherwood", "Amphos 2.0",          DC_FAMILY_OCEANIC_ATOM2, 0x4657, DC_TRANSPORT_SERIAL, NULL},
 	{"Sherwood", "Beacon",              DC_FAMILY_OCEANIC_ATOM2, 0x4742, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_oceanic},
 	{"Aqualung", "i470TC",              DC_FAMILY_OCEANIC_ATOM2, 0x4743, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_oceanic},
+	{"Aqualung", "i200Cv2",             DC_FAMILY_OCEANIC_ATOM2, 0x4749, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_oceanic},
 	/* Mares Nemo */
 	{"Mares", "Nemo",         DC_FAMILY_MARES_NEMO, 0, DC_TRANSPORT_SERIAL, NULL},
 	{"Mares", "Nemo Steel",   DC_FAMILY_MARES_NEMO, 0, DC_TRANSPORT_SERIAL, NULL},
@@ -705,6 +706,7 @@ static int dc_filter_oceanic (dc_transport_t transport, const void *userdata, vo
 		0x4656, // Oceanic Pro Plus 4
 		0x4742, // Sherwood Beacon
 		0x4743, // Aqualung i470TC
+		0x4749, // Aqualung i200C (newer model)
 	};
 
 	if (transport == DC_TRANSPORT_BLE) {

--- a/src/oceanic_atom2_parser.c
+++ b/src/oceanic_atom2_parser.c
@@ -102,6 +102,7 @@
 #define AMPHOS2     0x4657
 #define BEACON      0x4742
 #define I470TC      0x4743
+#define I200CV2     0x4749
 
 #define NORMAL   0
 #define GAUGE    1
@@ -174,7 +175,7 @@ oceanic_atom2_parser_create (dc_parser_t **out, dc_context_t *context, unsigned 
 		model == A300 || model == MANTA ||
 		model == INSIGHT2 || model == ZEN ||
 		model == I300 || model == I550 ||
-		model == I200 || model == I200C ||
+		model == I200 || model == I200C || model == I200CV2 ||
 		model == I300C || model == GEO40 ||
 		model == VEO40 || model == I470TC) {
 		parser->headersize -= PAGESIZE;
@@ -301,6 +302,7 @@ oceanic_atom2_parser_get_datetime (dc_parser_t *abstract, dc_datetime_t *datetim
 		case I300:
 		case I200:
 		case I200C:
+		case I200CV2:
 		case I100:
 		case I300C:
 		case GEO40:
@@ -768,8 +770,8 @@ oceanic_atom2_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_
 		parser->model == MANTA || parser->model == I300 ||
 		parser->model == I200 || parser->model == I100 ||
 		parser->model == I300C || parser->model == TALIS ||
-		parser->model == I200C || parser->model == GEO40 ||
-		parser->model == VEO40) {
+		parser->model == I200C || parser->model == I200CV2 ||
+		parser->model == GEO40 || parser->model == VEO40) {
 		have_pressure = 0;
 	}
 
@@ -930,7 +932,7 @@ oceanic_atom2_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_
 					parser->model == I200 || parser->model == I100 ||
 					parser->model == I300C || parser->model == I200C ||
 					parser->model == GEO40 || parser->model == VEO40 ||
-					parser->model == I470TC) {
+					parser->model == I470TC || parser->model == I200CV2) {
 					temperature = data[offset + 3];
 				} else if (parser->model == OCS || parser->model == TX1) {
 					temperature = data[offset + 1];
@@ -1009,7 +1011,7 @@ oceanic_atom2_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_
 				parser->model == I200 || parser->model == I100 ||
 				parser->model == I300C || parser->model == I200C ||
 				parser->model == GEO40 || parser->model == VEO40 ||
-				parser->model == I470TC)
+				parser->model == I470TC || parser->model == I200CV2)
 				depth = (data[offset + 4] + (data[offset + 5] << 8)) & 0x0FFF;
 			else if (parser->model == ATOM1)
 				depth = data[offset + 3] * 16;
@@ -1065,7 +1067,7 @@ oceanic_atom2_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_
 				parser->model == I100 || parser->model == I300C ||
 				parser->model == I450T || parser->model == I200C ||
 				parser->model == GEO40 || parser->model == VEO40 ||
-				parser->model == I470TC) {
+				parser->model == I470TC || parser->model == I200CV2) {
 				decostop = (data[offset + 7] & 0xF0) >> 4;
 				decotime = array_uint16_le(data + offset + 6) & 0x0FFF;
 				have_deco = 1;


### PR DESCRIPTION
There appear to be newer models in the wild with a different model
number, but labeled as i200C.

this PR is not sufficient to correctly download everything, but it gets at least somewhat useful support for testing.
The one user with whom I have talked shows that most of the dive data look correct, but the dive date is bogus.

But with this change a user can download things at all, so it's definitely an improvement.