### PR TITLE
add Shearwater Perdix 2 and Petrel 3

### DIFF
--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -357,6 +357,8 @@ static const dc_descriptor_t g_descriptors[] = {
 	{"Shearwater", "Nerd 2",    DC_FAMILY_SHEARWATER_PETREL, 7, DC_TRANSPORT_BLE, dc_filter_shearwater},
 	{"Shearwater", "Teric",     DC_FAMILY_SHEARWATER_PETREL, 8, DC_TRANSPORT_BLE, dc_filter_shearwater},
 	{"Shearwater", "Peregrine", DC_FAMILY_SHEARWATER_PETREL, 9, DC_TRANSPORT_BLE, dc_filter_shearwater},
+	{"Shearwater", "Petrel 3",  DC_FAMILY_SHEARWATER_PETREL, 10, DC_TRANSPORT_BLE, dc_filter_shearwater},
+	{"Shearwater", "Perdix 2",  DC_FAMILY_SHEARWATER_PETREL, 11, DC_TRANSPORT_BLE, dc_filter_shearwater},
 	/* Dive Rite NiTek Q */
 	{"Dive Rite", "NiTek Q",   DC_FAMILY_DIVERITE_NITEKQ, 0, DC_TRANSPORT_SERIAL, NULL},
 	/* Citizen Hyper Aqualand */
@@ -631,9 +633,11 @@ static int dc_filter_shearwater (dc_transport_t transport, const void *userdata,
 	static const char * const bluetooth[] = {
 		"Predator",
 		"Petrel",
+		"Petrel 3",
 		"NERD",
 		"NERD 2",
 		"Perdix",
+		"Perdix 2",
 		"Teric",
 		"Peregrine",
 	};

--- a/src/shearwater_common.h
+++ b/src/shearwater_common.h
@@ -43,6 +43,8 @@ extern "C" {
 #define NERD2    7
 #define TERIC    8
 #define PEREGRINE 9
+#define PETREL3  10
+#define PERDIX2  11
 
 #define NSTEPS    10000
 #define STEP(i,n) ((NSTEPS * (i) + (n) / 2) / (n))

--- a/src/shearwater_petrel.c
+++ b/src/shearwater_petrel.c
@@ -220,29 +220,42 @@ shearwater_petrel_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
 	case 0x0A0A: // Nerd 1
 		model = NERD;
 		break;
+	case 0x7E2D:
 	case 0x0E0D: // Nerd 2
 		model = NERD2;
 		break;
 	case 0x0404:
 	case 0x0909: // Petrel 1
-	case 0x0B0B: // Petrel 1 (newer hardware)
 		model = PETREL;
 		break;
 	case 0x0505:
-	case 0x0808: // Petrel 2
+	case 0x0808:
+	case 0x0838:
+	case 0x08A5:
+	case 0x7828:
+	case 0x7B2C:
+	case 0x8838: // Petrel 2
+	case 0x0B0B: // current docs (June 2023) imply this is a Petrel 2
 		model = PETREL;
 		break;
-	case 0x0707: // documentation list 0C0D for both Perdix and Perdix AI :-(
+	case 0xB407: // Petrel 3
+		model = PETREL3;
+		break;
+	case 0x0707: // Perdix
 		model = PERDIX;
 		break;
-	case 0x0C0C:
-	case 0x0C0D:
-	case 0x0D0D:
-	case 0x7C2D:
+	case 0x0C0C: // current docs (June 2023) imply this is not a valid hardware ID
+	case 0x0C0D: // current docs (June 2023) show this as Perdix AI
+	case 0x0D0D: // current docs (June 2023) imply this is not a valid hardware ID
+	case 0x7C2D: // Perdix AI
 		model = PERDIXAI;
+		break;
+	case 0xC407: // Perdix 2
+		model = PERDIX2;
 		break;
 	case 0x0F0F:
 	case 0x1F0A:
+	case 0x1F0F:
 		model = TERIC;
 		break;
 	case 0x1512:


### PR DESCRIPTION
Also update and fix the hardware IDs based on the latest information
from Shearwater.
Two of the hardware IDs that we supported before are no listed in the
current docs. In an abundance of caution I'll leave them in the code.
No harm done if they don't exist in real life.


I have tested this with a Perdix 2 that came with the typical one test dive on it. It downloads just fine.
While I got access to the latest hardware IDs, I don't have the updated firmware info, yet, so I expect that there will be a few more changes to add new features - but for now this should get people started.