### PR TITLE
Added parsing of the CCR setpoint information for Garmin Descent computers.

### DIFF
--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -449,6 +449,7 @@ static const dc_descriptor_t g_descriptors[] = {
 
 	// Not merged upstream yet
 	/* Garmin -- model numbers as defined in FIT format; USB product id is (0x4000 | model) */
+	/* for the Mk1 we are using the model of the global model - the APAC model is 2991 */
 	/* for the Mk2 we are using the model of the global model - the APAC model is 3702 */
 	{"Garmin", "Descent Mk1", DC_FAMILY_GARMIN, 2859, DC_TRANSPORT_USBSTORAGE, dc_filter_garmin},
 	{"Garmin", "Descent Mk2/Mk2i", DC_FAMILY_GARMIN, 3258, DC_TRANSPORT_USBSTORAGE, dc_filter_garmin},

--- a/src/field-cache.c
+++ b/src/field-cache.c
@@ -9,7 +9,7 @@
  * The field cache 'string' interface has some simple rules:
  * the "descriptor" part is assumed to be a static allocation,
  * while the "value" is something that this interface will
- * alway sallocate with 'strdup()', so you can generate it
+ * always allocate with 'strdup()', so you can generate it
  * dynamically on the stack or whatever without having to
  * worry about it.
  */


### PR DESCRIPTION
This is adding support for parsing the setpoint information in logfiles downloaded from Garmin Descent devices.

![Screenshot from 2022-11-24 11-25-25](https://user-images.githubusercontent.com/4742747/203656272-6c8c9fc6-52bf-455e-9190-f4f77ff859cc.png)

The Garmin devices do not have support for ppO2 sensor input, so they only work in 'fixed setpoint' mode for CCR dives, and dive data records do not contain actual ppO2 values. The ppO2 values are retrofitted to the dive data based on 'setpoint change' events reported by the device. With this change CCR dives downloaded from a Garmin device are correctly classified as CCR dive, and the calculated ceiling / tissue loading graphs are accurate and match the deco stops reported by the device. Before this change, CCR dives were classified as open circuit dives, often resulting in a massively overstated calculated ceiling.

This has been tested for logs with only automated setpoint changes - more test dives are needed to reverse engineer the log file format for manual setpoint changes, as the setpoint fields are not documented in Garmin's documentation for the FIT file format.

Signed-off-by: Michael Keller <github@ike.ch>