### PR TITLE
Refactoring: Push field cache access down into base class.

### DIFF
--- a/src/deepblu_parser.c
+++ b/src/deepblu_parser.c
@@ -210,33 +210,11 @@ deepblu_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigned 
 		return DC_STATUS_UNSUPPORTED;
 
 	switch (type) {
-	case DC_FIELD_DIVETIME:
-		return DC_FIELD_VALUE(deepblu->cache, value, DIVETIME);
-	case DC_FIELD_MAXDEPTH:
-		return DC_FIELD_VALUE(deepblu->cache, value, MAXDEPTH);
-	case DC_FIELD_AVGDEPTH:
-		return DC_FIELD_VALUE(deepblu->cache, value, AVGDEPTH);
-	case DC_FIELD_GASMIX_COUNT:
-	case DC_FIELD_TANK_COUNT:
-		return DC_FIELD_VALUE(deepblu->cache, value, GASMIX_COUNT);
-	case DC_FIELD_GASMIX:
-		if (flags >= MAXGASES)
-			return DC_STATUS_UNSUPPORTED;
-		return DC_FIELD_INDEX(deepblu->cache, value, GASMIX, flags);
-	case DC_FIELD_SALINITY:
-		return DC_FIELD_VALUE(deepblu->cache, value, SALINITY);
-	case DC_FIELD_ATMOSPHERIC:
-		return DC_FIELD_VALUE(deepblu->cache, value, ATMOSPHERIC);
-	case DC_FIELD_DIVEMODE:
-		return DC_FIELD_VALUE(deepblu->cache, value, DIVEMODE);
 	case DC_FIELD_TANK:
 		return DC_STATUS_UNSUPPORTED;
-	case DC_FIELD_STRING:
-		return dc_field_get_string(&deepblu->cache, flags, (dc_field_string_t *)value);
-	default:
-		return DC_STATUS_UNSUPPORTED;
 	}
-	return DC_STATUS_SUCCESS;
+
+	return dc_field_get(&deepblu->cache, type, flags, value);
 }
 
 static dc_status_t

--- a/src/field-cache.c
+++ b/src/field-cache.c
@@ -93,8 +93,22 @@ dc_field_get(dc_field_cache_t *cache, dc_field_type_t type, unsigned int flags, 
 		return DC_FIELD_INDEX(*cache, value, GASMIX, flags);
 	case DC_FIELD_SALINITY:
 		return DC_FIELD_VALUE(*cache, value, SALINITY);
+	case DC_FIELD_ATMOSPHERIC:
+		return DC_FIELD_VALUE(*cache, value, ATMOSPHERIC);
 	case DC_FIELD_DIVEMODE:
 		return DC_FIELD_VALUE(*cache, value, DIVEMODE);
+	case DC_FIELD_TANK:
+		if (flags >= MAXGASES)
+			break;
+
+		dc_tank_t *tank = (dc_tank_t *) value;
+
+		tank->volume = cache->tanksize[flags];
+		tank->gasmix = flags;
+		tank->workpressure = cache->tankworkingpressure[flags];
+		tank->type = cache->tankinfo[flags];
+
+		return DC_STATUS_SUCCESS;
 	case DC_FIELD_STRING:
 		return dc_field_get_string(cache, flags, (dc_field_string_t *)value);
 	default:

--- a/src/field-cache.h
+++ b/src/field-cache.h
@@ -22,7 +22,7 @@ typedef struct dc_field_cache {
 	double highsetpoint;
 	double customsetpoint;
 
-	// This (slong with GASMIX) should be something like
+	// This (along with GASMIX) should be something like
 	//     dc_tank_t TANK[MAXGASES]
 	// but that's for later
 	dc_tankinfo_t tankinfo[MAXGASES];

--- a/src/suunto_eonsteel_parser.c
+++ b/src/suunto_eonsteel_parser.c
@@ -1008,36 +1008,18 @@ suunto_eonsteel_parser_samples_foreach(dc_parser_t *abstract, dc_sample_callback
 static dc_status_t
 suunto_eonsteel_parser_get_field(dc_parser_t *parser, dc_field_type_t type, unsigned int flags, void *value)
 {
-	dc_tank_t *tank = (dc_tank_t *) value;
-
 	suunto_eonsteel_parser_t *eon = (suunto_eonsteel_parser_t *)parser;
 
 	if (!(eon->cache.initialized & (1 << type)))
 		return DC_STATUS_UNSUPPORTED;
 
 	switch (type) {
-	case DC_FIELD_DIVETIME:
-		return DC_FIELD_VALUE(eon->cache, value, DIVETIME);
-	case DC_FIELD_MAXDEPTH:
-		return DC_FIELD_VALUE(eon->cache, value, MAXDEPTH);
-	case DC_FIELD_AVGDEPTH:
-		return DC_FIELD_VALUE(eon->cache, value, AVGDEPTH);
-	case DC_FIELD_GASMIX_COUNT:
-	case DC_FIELD_TANK_COUNT:
-		return DC_FIELD_VALUE(eon->cache, value, GASMIX_COUNT);
-	case DC_FIELD_GASMIX:
-		if (flags >= MAXGASES)
-			return DC_STATUS_UNSUPPORTED;
-		return DC_FIELD_INDEX(eon->cache, value, GASMIX, flags);
-	case DC_FIELD_SALINITY:
-		return DC_FIELD_VALUE(eon->cache, value, SALINITY);
-	case DC_FIELD_ATMOSPHERIC:
-		return DC_FIELD_VALUE(eon->cache, value, ATMOSPHERIC);
-	case DC_FIELD_DIVEMODE:
-		return DC_FIELD_VALUE(eon->cache, value, DIVEMODE);
 	case DC_FIELD_TANK:
 		if (flags >= MAXGASES)
 			return DC_STATUS_UNSUPPORTED;
+
+		dc_tank_t *tank = (dc_tank_t *) value;
+
 		/*
 		 * Sadly it seems that the EON Steel doesn't tell us whether
 		 * we get imperial or metric data - the only indication is
@@ -1067,12 +1049,9 @@ suunto_eonsteel_parser_get_field(dc_parser_t *parser, dc_field_type_t type, unsi
 				tank->type += DC_TANKINFO_IMPERIAL - DC_TANKINFO_METRIC;
 		}
 		break;
-	case DC_FIELD_STRING:
-		return dc_field_get_string(&eon->cache, flags, (dc_field_string_t *)value);
-	default:
-		return DC_STATUS_UNSUPPORTED;
 	}
-	return DC_STATUS_SUCCESS;
+
+	return dc_field_get(&eon->cache, type, flags, value);
 }
 
 /*


### PR DESCRIPTION
Pushed access to cached fields down into `field-cache.c` from parsers that use the field cache.
As a result, all cached fields will be available to Subsurface in computer models that use the field cache. In particular this means that, together with https://github.com/subsurface/libdc/pull/41, the proper use type (diluent / OC bailout) of tanks will be shown for the Garmin Descent dive computers (others to follow).

![image](https://user-images.githubusercontent.com/4742747/212841979-c953e1a9-1c5c-466a-96d5-477c13c7208b.png)


Signed-off-by: Michael Keller <github@ike.ch>