### PR TITLE
HW OSTC4: Fix and improve CCR gas handling.

### DIFF
--- a/src/hw_ostc_parser.c
+++ b/src/hw_ostc_parser.c
@@ -1057,7 +1057,7 @@ hw_ostc_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_t call
 				return DC_STATUS_DATAFORMAT;
 			}
 			unsigned int idx = data[offset];
-			if (parser->model == OSTC4 && ccr && idx > parser->nfixed && idx <= parser->nfixed + OSTC4_CC_DILUENT_GAS_OFFSET) {
+			if (idx > parser->nfixed && idx <= parser->nfixed + OSTC4_CC_DILUENT_GAS_OFFSET) {
 				// OSTC4 reports gas changes to another diluent with an offset
 				idx -= OSTC4_CC_DILUENT_GAS_OFFSET;
 			}

--- a/src/hw_ostc_parser.c
+++ b/src/hw_ostc_parser.c
@@ -573,6 +573,7 @@ hw_ostc_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigned 
 				return DC_STATUS_UNSUPPORTED;
 			*((double *) value) = array_uint16_le (data + layout->avgdepth) / 100.0;
 			break;
+		case DC_FIELD_TANK_COUNT:
 		case DC_FIELD_GASMIX_COUNT:
 			*((unsigned int *) value) = parser->ngasmixes;
 			break;
@@ -580,6 +581,19 @@ hw_ostc_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigned 
 			gasmix->oxygen = parser->gasmix[flags].oxygen / 100.0;
 			gasmix->helium = parser->gasmix[flags].helium / 100.0;
 			gasmix->nitrogen = 1.0 - gasmix->oxygen - gasmix->helium;
+			break;
+		case DC_FIELD_TANK:
+			if (flags >= parser->ngasmixes) {
+				return DC_STATUS_UNSUPPORTED;
+			}
+
+			dc_tank_t *tank = (dc_tank_t *) value;
+
+			tank->volume = 0.0;
+			tank->gasmix = flags;
+			tank->workpressure = 0.0;
+			tank->type = DC_TANKINFO_METRIC | (parser->gasmix[flags].diluent ? DC_TANKINFO_CC_DILUENT : 0);
+
 			break;
 		case DC_FIELD_SALINITY:
 			if (salinity < 100 || salinity > 104)


### PR DESCRIPTION
Fixed a bug for the OSTC4 using the wrong gas after (diluent) gas changes because the diluent gas index is offset by 5 when in CCR mode. Also added proper tracking of gas use type (diluent / OC bailout) during CCR dives, and added explicit events for OC bailout / switch back to closed circuit.
This intentionally only handles OSTC4 data - I do not own any other Heinrichs Weikamp devices, and have got no easy way to figure out if any of their other models with CCR support have the same quirk of remapping diluent gases in the log header. If somebody owns such a device and can test for me I am happy to make the changes for other devices.

![image](https://user-images.githubusercontent.com/4742747/218377602-5201368b-e1fe-40af-bb47-a76491491ae0.png)


Signed-off-by: Michael Keller <github@ike.ch>