### PR TITLE
Heinrichs Weikamp: Increase parameter value buffer size.

### DIFF
--- a/src/hw_ostc_parser.c
+++ b/src/hw_ostc_parser.c
@@ -525,7 +525,7 @@ hw_ostc_parser_get_datetime (dc_parser_t *abstract, dc_datetime_t *datetime)
 	return DC_STATUS_SUCCESS;
 }
 
-#define BUFLEN 32
+#define BUFLEN 64
 
 static dc_status_t
 hw_ostc_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigned int flags, void *value)


### PR DESCRIPTION
Get rid of truncation warnings and possible string truncation by increasing the size of the buffer used for parameter values. There is enough space to display up to 64 characters.

![image](https://user-images.githubusercontent.com/4742747/218380343-15e7fbb1-4668-4239-aae5-9cb1e0008786.png)

Signed-off-by: Michael Keller <github@ike.ch>