### PR TITLE
Shearwater: Add time synchronisation.

### DIFF
--- a/src/shearwater_common.h
+++ b/src/shearwater_common.h
@@ -34,6 +34,9 @@ extern "C" {
 #define ID_FIRMWARE  0x8011
 #define ID_LOGUPLOAD 0x8021
 #define ID_HARDWARE  0x8050
+#define ID_TIME      0x9030
+
+#define WDBI_TIME_PACKET_SIZE 7
 
 #define PREDATOR 2
 #define PETREL   3
@@ -66,6 +69,10 @@ shearwater_common_download (shearwater_common_device_t *device, dc_buffer_t *buf
 
 dc_status_t
 shearwater_common_identifier (shearwater_common_device_t *device, dc_buffer_t *buffer, unsigned int id);
+
+dc_status_t shearwater_common_can_wdbi (shearwater_common_device_t *device, dc_buffer_t *buffer, unsigned int id);
+
+dc_status_t shearwater_common_device_timesync(dc_device_t *abstract, const dc_datetime_t *datetime);
 
 #ifdef __cplusplus
 }

--- a/src/shearwater_petrel.c
+++ b/src/shearwater_petrel.c
@@ -44,6 +44,16 @@ typedef struct shearwater_petrel_device_t {
 	unsigned char fingerprint[4];
 } shearwater_petrel_device_t;
 
+
+static dc_status_t shearwater_petrel_device_timesync(dc_device_t *abstract, const dc_datetime_t *datetime)
+{
+	// The Teric will need a different implementation
+	// to properly support time zones
+
+	return shearwater_common_device_timesync(abstract, datetime);
+}
+
+
 static dc_status_t shearwater_petrel_device_set_fingerprint (dc_device_t *abstract, const unsigned char data[], unsigned int size);
 static dc_status_t shearwater_petrel_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, void *userdata);
 static dc_status_t shearwater_petrel_device_close (dc_device_t *abstract);
@@ -56,7 +66,7 @@ static const dc_device_vtable_t shearwater_petrel_device_vtable = {
 	NULL, /* write */
 	NULL, /* dump */
 	shearwater_petrel_device_foreach, /* foreach */
-	NULL, /* timesync */
+	shearwater_petrel_device_timesync,
 	shearwater_petrel_device_close /* close */
 };
 

--- a/src/shearwater_predator.c
+++ b/src/shearwater_predator.c
@@ -53,7 +53,7 @@ static const dc_device_vtable_t shearwater_predator_device_vtable = {
 	NULL, /* write */
 	shearwater_predator_device_dump, /* dump */
 	shearwater_predator_device_foreach, /* foreach */
-	NULL, /* timesync */
+	shearwater_common_device_timesync,
 	NULL /* close */
 };
 


### PR DESCRIPTION
Add time synchronisation for Shearwater dive computers. This synchronises the local time, which is all that is supported by all Shearwater models except for the Teric.
Time synchronisation including the time zone for the Teric still has to be added.