### PR TITLE
HW OSTC3/4: Mark Inactive Gases as Such.

### DIFF
--- a/src/hw_ostc_parser.c
+++ b/src/hw_ostc_parser.c
@@ -578,12 +578,21 @@ hw_ostc_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigned 
 			*((unsigned int *) value) = parser->ngasmixes;
 			break;
 		case DC_FIELD_GASMIX:
+			if (flags >= parser->ngasmixes) {
+				return DC_STATUS_UNSUPPORTED;
+			}
+
 			gasmix->oxygen = parser->gasmix[flags].oxygen / 100.0;
 			gasmix->helium = parser->gasmix[flags].helium / 100.0;
 			gasmix->nitrogen = 1.0 - gasmix->oxygen - gasmix->helium;
+			if (!parser->gasmix[flags].enabled) {
+				// Indicate that this gasmix is not active
+				return DC_STATUS_UNSUPPORTED;
+			}
+
 			break;
 		case DC_FIELD_TANK:
-			if (flags >= parser->ngasmixes) {
+			if (flags >= parser->ngasmixes || !parser->gasmix[flags].enabled) {
 				return DC_STATUS_UNSUPPORTED;
 			}
 


### PR DESCRIPTION
Return `DC_STATUS_UNSUPPORTED` for inactive gas mixes, while retaining the configured gas information. This makes it possible to mark inactive gases as such, or completely hide them, without affecting the gas indices that are referenced in gas switches.

![image](https://github.com/subsurface/libdc/assets/4742747/24e98c6f-820d-4922-9c76-9fbba9c75259)
