### PR TITLE
Cressi Leonardo: Turn ascent warnings into info events.

### DIFF
--- a/src/cressi_leonardo_parser.c
+++ b/src/cressi_leonardo_parser.c
@@ -229,8 +229,13 @@ cressi_leonardo_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callbac
 			if (ascent) {
 				sample.event.type = SAMPLE_EVENT_ASCENT;
 				sample.event.time = 0;
-				sample.event.flags = 0;
+				if (ascent < 3)
+					// Turn the overly sensitive ascent warnings of this dive computer into info events
+					sample.event.flags = SAMPLE_FLAGS_SEVERITY_INFO;
+				else
+					sample.event.flags = 0;
 				sample.event.value = ascent;
+
 				if (callback) callback (DC_SAMPLE_EVENT, sample, userdata);
 			}
 


### PR DESCRIPTION
According to user feedback the ascent warnings on the Cressi Leonardo are very sensitive. They come in 3 different levels. This change turns levels 1 and 2 into info events, leaving only 3 as a warning.
Fixes https://groups.google.com/g/subsurface-divelog/c/qBXF0wmyjKg/m/5qA0_KABCQAJ

![Screenshot from 2023-07-25 00-25-22](https://github.com/subsurface/libdc/assets/4742747/2321b42b-cf5f-45ff-b540-297b2f88aae5)
