### PR TITLE
Garmin: Add Support for Parsing of Garmin Descent Mk3 FIT files.

### DIFF
--- a/src/garmin_parser.c
+++ b/src/garmin_parser.c
@@ -30,7 +30,7 @@
 #include "array.h"
 #include "field-cache.h"
 
-#define MAXFIELDS 128
+#define MAXFIELDS 160
 
 struct msg_desc;
 


### PR DESCRIPTION
Add support for FIT files generated by the Garmin Descent Mk3. This just fixes a field number limitation, it has not yet been verified that the Mk3 file format is properly interpreted by Subsurface.