### PR TITLE
Garmin: Add Support for Descent Mk3(i).

### DIFF
--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -471,10 +471,11 @@ static const dc_descriptor_t g_descriptors[] = {
 
 	// Not merged upstream yet
 	/* Garmin -- model numbers as defined in FIT format; USB product id is (0x4000 | model) */
-	/* for the Mk1 we are using the model of the global model - the APAC model is 2991 */
-	/* for the Mk2 we are using the model of the global model - the APAC model is 3702 */
+	/* for the Mk1 we are using the model of the global model */
+	/* for the Mk2/Mk3 we are using the model of the Mk2 global model */
+	/* see garmin_parser.c for a more comprehensive list of models */
 	{"Garmin", "Descent Mk1", DC_FAMILY_GARMIN, 2859, DC_TRANSPORT_USBSTORAGE, dc_filter_garmin},
-	{"Garmin", "Descent Mk2/Mk2i", DC_FAMILY_GARMIN, 3258, DC_TRANSPORT_USBSTORAGE, dc_filter_garmin},
+	{"Garmin", "Descent Mk2(i)/Mk3(i)", DC_FAMILY_GARMIN, 3258, DC_TRANSPORT_USBSTORAGE, dc_filter_garmin},
 	{"FIT", "File import", DC_FAMILY_GARMIN, 0, DC_TRANSPORT_USBSTORAGE, NULL },
 };
 

--- a/src/garmin.c
+++ b/src/garmin.c
@@ -101,7 +101,6 @@ garmin_device_open (dc_device_t **out, dc_context_t *context, dc_iostream_t *ios
 	// in order to have only one entry for the Mk2, we don't use the Mk2/APAC model number in our code
 	device->use_mtp = (model == (0x0FFF & DESCENT_MK2));
 	device->mtp_device = NULL;
-	DEBUG(context, "Found Garmin with model 0x%x which is a %s\n", model, (device->use_mtp ? "Mk2/Mk2i" : "Mk1"));
 #endif
 
 	*out = (dc_device_t *) device;
@@ -331,9 +330,13 @@ mtp_get_file_list(dc_device_t *abstract, struct file_list *files)
 	for (i = 0; i < numrawdevices; i++) {
 		LIBMTP_devicestorage_t *storage;
 		// we only want to read from a Garmin Descent Mk2 device at this point
-		if (rawdevices[i].device_entry.vendor_id != GARMIN_VENDOR ||
-		    (rawdevices[i].device_entry.product_id != DESCENT_MK2 && rawdevices[i].device_entry.product_id != DESCENT_MK2_APAC)) {
+		if (rawdevices[i].device_entry.vendor_id != GARMIN_VENDOR) {
 			DEBUG(abstract->context, "Garmin/mtp: skipping raw device %04x/%04x",
+			      rawdevices[i].device_entry.vendor_id, rawdevices[i].device_entry.product_id);
+			continue;
+		}
+		if (rawdevices[i].device_entry.product_id != DESCENT_MK2 && rawdevices[i].device_entry.product_id != DESCENT_MK2_APAC) {
+			DEBUG(abstract->context, "Garmin/mtp: skipping Garmin raw device %04x/%04x, as it is not a dive computer / does not support MTP",
 			      rawdevices[i].device_entry.vendor_id, rawdevices[i].device_entry.product_id);
 			continue;
 		}


### PR DESCRIPTION
Add support for the Garmin Descent Mk3(i) models.

This pretty much just updates the entry in the device list to cover Mk2 and Mk3 models.
It does nothing to add support for MTP when reading from an Mk3 model - I have not been able to get MTP support on linux going reliably, and I do not have an Mk2 / Mk3 to test with anyway.
I suspect that MTP support is incomplete anyway, as the product IDs for models like the Mk2S and Mk2G are not detected.

This change also adds an extra info field for the Model (based on a heuristic and incomplete list).
@torvalds do you have any contact information for Garmin - asking them for a list of model IDs (and USB product IDs) is probably the best approach to get this improved.
I have also added more detailed debug information that could help with guessing the USB product IDs for Descent models that support MTP.

It also fixes the data type for the sensor_type field.