### PR TITLE
Fix the Mares usb-serial communication

### DIFF
--- a/src/mares_iconhd.c
+++ b/src/mares_iconhd.c
@@ -183,6 +183,7 @@ mares_iconhd_packet (mares_iconhd_device_t *device,
 {
 	dc_status_t status = DC_STATUS_SUCCESS;
 	dc_device_t *abstract = (dc_device_t *) device;
+	dc_transport_t transport = dc_iostream_get_transport (device->iostream);
 
 	if (device_is_cancelled (abstract))
 		return DC_STATUS_CANCELLED;
@@ -198,7 +199,7 @@ mares_iconhd_packet (mares_iconhd_device_t *device,
 	}
 
 	// Send the command payload to the dive computer.
-	if (size) {
+	if (size && transport == DC_TRANSPORT_BLE) {
 		status = dc_iostream_write (device->iostream, data, size, NULL);
 		if (status != DC_STATUS_SUCCESS) {
 			ERROR (abstract->context, "Failed to send the command.");
@@ -218,6 +219,15 @@ mares_iconhd_packet (mares_iconhd_device_t *device,
 	if (header[0] != ACK) {
 		ERROR (abstract->context, "Unexpected answer byte.");
 		return DC_STATUS_PROTOCOL;
+	}
+
+	// Send the command payload to the dive computer.
+	if (size && transport != DC_TRANSPORT_BLE) {
+		status = dc_iostream_write (device->iostream, data, size, NULL);
+		if (status != DC_STATUS_SUCCESS) {
+			ERROR (abstract->context, "Failed to send the command data.");
+			return status;
+		}
 	}
 
 	// Read the packet.


### PR DESCRIPTION
@torvalds: I cherry-picked this from https://github.com/libdivecomputer/libdivecomputer/commit/8745a3b95af66c630ff771012f24c46dbea137c2 - there have been multiple reports from users with Mares dive computers running into this when using latest Subsurface:
- https://groups.google.com/g/subsurface-divelog/c/nu4SHPL1xTY/m/c4D6Ngd4AwAJ
- Fixes https://github.com/subsurface/subsurface/issues/4174

I suspect that this might need some manual conflict resolution next time we merge from libdivecomputer, but I am happy to deal with this there and then.

Original commit message:
> The BLE changes in commit e83732e200620882b13804f1ca54c1ab90a38188 are causing major problems for some of the usb-serial enabled models, like the Puck Pro and Quad Air.

>These models appear to require a small delay of a few milliseconds between sending the two command bytes and the remainder of the command payload. I suspect the device is still busy processing those first two bytes, and thus not ready in time to receive the remaining data. Instead of manually adding a fixed delay, restore the previous behaviour and wait for the ack byte again. This has the advantage that the delay is automatically proportional to the response time of the dive computer.

> For the BLE communication nothing changes.