### PR TITLE
Garmin: Fix Reporting of Sensor Count.

### DIFF
--- a/src/field-cache.c
+++ b/src/field-cache.c
@@ -85,8 +85,9 @@ dc_field_get(dc_field_cache_t *cache, dc_field_type_t type, unsigned int flags, 
 	case DC_FIELD_AVGDEPTH:
 		return DC_FIELD_VALUE(*cache, value, AVGDEPTH);
 	case DC_FIELD_GASMIX_COUNT:
-	case DC_FIELD_TANK_COUNT:
 		return DC_FIELD_VALUE(*cache, value, GASMIX_COUNT);
+	case DC_FIELD_TANK_COUNT:
+		return DC_FIELD_VALUE(*cache, value, TANK_COUNT);
 	case DC_FIELD_GASMIX:
 		if (flags >= MAXGASES)
 			break;

--- a/src/field-cache.h
+++ b/src/field-cache.h
@@ -14,6 +14,7 @@ typedef struct dc_field_cache {
 	double ATMOSPHERIC;
 	dc_divemode_t DIVEMODE;
 	unsigned int GASMIX_COUNT;
+	unsigned int TANK_COUNT;
 	dc_salinity_t SALINITY;
 	dc_gasmix_t GASMIX[MAXGASES];
 

--- a/src/garmin_parser.c
+++ b/src/garmin_parser.c
@@ -1696,8 +1696,8 @@ garmin_parser_set_data (garmin_parser_t *garmin, const unsigned char *data, unsi
 	//
 	// There's no way to match them up unless they are an identity
 	// mapping, so having two different ones doesn't actually work.
-	if (garmin->dive.nr_sensor > garmin->cache.GASMIX_COUNT)
-		DC_ASSIGN_FIELD(garmin->cache, GASMIX_COUNT, garmin->dive.nr_sensor);
+	if (garmin->dive.nr_sensor > garmin->cache.TANK_COUNT)
+		DC_ASSIGN_FIELD(garmin->cache, TANK_COUNT, garmin->dive.nr_sensor);
 
 	for (int i = 0; i < garmin->dive.nr_sensor; i++) {
 		static const char *name[] = { "Sensor 1", "Sensor 2", "Sensor 3", "Sensor 4", "Sensor 5" };


### PR DESCRIPTION
Report the number of tank sensors independently of the number of gasmixes. This fixes an unintuitive error message popping up when importing dives with more sensors than gasmixes.

Fixes https://github.com/subsurface/subsurface/issues/4221.

Reported-by: @bwong2132