### PR TITLE
Update libdivecomputer from Upstream.

### DIFF
--- a/contrib/android/Android.mk
+++ b/contrib/android/Android.mk
@@ -9,6 +9,7 @@ LOCAL_SRC_FILES := \
 	src/array.c \
 	src/atomics_cobalt.c \
 	src/atomics_cobalt_parser.c \
+	src/ble.c \
 	src/bluetooth.c \
 	src/buffer.c \
 	src/checksum.c \

--- a/contrib/msvc/libdivecomputer.vcxproj
+++ b/contrib/msvc/libdivecomputer.vcxproj
@@ -177,6 +177,7 @@
     <ClCompile Include="..\..\src\array.c" />
     <ClCompile Include="..\..\src\atomics_cobalt.c" />
     <ClCompile Include="..\..\src\atomics_cobalt_parser.c" />
+    <ClCompile Include="..\..\src\ble.c" />
     <ClCompile Include="..\..\src\bluetooth.c" />
     <ClCompile Include="..\..\src\buffer.c" />
     <ClCompile Include="..\..\src\checksum.c" />

--- a/examples/dctool_timesync.c
+++ b/examples/dctool_timesync.c
@@ -85,10 +85,10 @@ do_timesync (dc_context_t *context, dc_descriptor_t *descriptor, dc_transport_t 
 	}
 
 	// Syncronize the device clock.
-	message ("Syncronize the device clock.\n");
+	message ("Synchronize the device clock.\n");
 	rc = dc_device_timesync (device, datetime);
 	if (rc != DC_STATUS_SUCCESS) {
-		ERROR ("Error syncronizing the device clock.");
+		ERROR ("Error synchronizing the device clock.");
 		goto cleanup;
 	}
 

--- a/include/libdivecomputer/ble.h
+++ b/include/libdivecomputer/ble.h
@@ -61,9 +61,45 @@ extern "C" {
 #define DC_IOCTL_BLE_CHARACTERISTIC_WRITE DC_IOCTL_IOW('b', 3, DC_IOCTL_SIZE_VARIABLE)
 
 /**
+ * The minimum number of bytes (including the terminating null byte) for
+ * formatting a bluetooth UUID as a string.
+ */
+#define DC_BLE_UUID_SIZE 37
+
+/**
  * Bluetooth UUID (128 bits).
  */
 typedef unsigned char dc_ble_uuid_t[16];
+
+/**
+ * Convert a bluetooth UUID to a string.
+ *
+ * The bluetooth UUID is formatted as
+ * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX, where each XX pair is a
+ * hexadecimal number specifying an octet of the UUID.
+ * The minimum size for the buffer is #DC_BLE_UUID_SIZE bytes.
+ *
+ * @param[in]  uuid     A bluetooth UUID.
+ * @param[in]  str      The memory buffer to store the result.
+ * @param[in]  size     The size of the memory buffer.
+ * @returns The null-terminated string on success, or NULL on failure.
+ */
+char *
+dc_ble_uuid2str (const dc_ble_uuid_t uuid, char *str, size_t size);
+
+/**
+ * Convert a string to a bluetooth UUID.
+ *
+ * The string is expected to be in the format
+ * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX, where each XX pair is a
+ * hexadecimal number specifying an octet of the UUID.
+ *
+ * @param[in]  str      A null-terminated string.
+ * @param[in]  uuid     The memory buffer to store the result.
+ * @returns Non-zero on success, or zero on failure.
+ */
+int
+dc_ble_str2uuid (const char *str, dc_ble_uuid_t uuid);
 
 #ifdef __cplusplus
 }

--- a/include/libdivecomputer/ble.h
+++ b/include/libdivecomputer/ble.h
@@ -48,6 +48,23 @@ extern "C" {
 #define DC_IOCTL_BLE_GET_ACCESSCODE   DC_IOCTL_IOR('b', 2, DC_IOCTL_SIZE_VARIABLE)
 #define DC_IOCTL_BLE_SET_ACCESSCODE   DC_IOCTL_IOW('b', 2, DC_IOCTL_SIZE_VARIABLE)
 
+/**
+ * Perform a BLE characteristic read/write operation.
+ *
+ * The UUID of the characteristic must be specified as a #dc_ble_uuid_t
+ * data structure. If the operation requires additional data as in- or
+ * output, the buffer must be located immediately after the
+ * #dc_ble_uuid_t data structure. The size of the ioctl request is the
+ * total size, including the size of the #dc_ble_uuid_t structure.
+ */
+#define DC_IOCTL_BLE_CHARACTERISTIC_READ  DC_IOCTL_IOR('b', 3, DC_IOCTL_SIZE_VARIABLE)
+#define DC_IOCTL_BLE_CHARACTERISTIC_WRITE DC_IOCTL_IOW('b', 3, DC_IOCTL_SIZE_VARIABLE)
+
+/**
+ * Bluetooth UUID (128 bits).
+ */
+typedef unsigned char dc_ble_uuid_t[16];
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -88,6 +88,7 @@ libdivecomputer_la_SOURCES = \
 	irda.c \
 	usb.c \
 	usbhid.c \
+	ble.c \
 	bluetooth.c \
 	custom.c
 

--- a/src/ble.c
+++ b/src/ble.c
@@ -1,0 +1,97 @@
+/*
+ * libdivecomputer
+ *
+ * Copyright (C) 2024 Jef Driesen
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301 USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+
+#include <libdivecomputer/ble.h>
+
+#include "platform.h"
+
+char *
+dc_ble_uuid2str (const dc_ble_uuid_t uuid, char *str, size_t size)
+{
+	if (str == NULL || size < DC_BLE_UUID_SIZE)
+		return NULL;
+
+	int n = dc_platform_snprintf(str, size,
+		"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+		uuid[0], uuid[1], uuid[2], uuid[3],
+		uuid[4], uuid[5],
+		uuid[6], uuid[7],
+		uuid[8], uuid[9],
+		uuid[10], uuid[11], uuid[12],
+		uuid[13], uuid[14], uuid[15]);
+	if (n < 0 || (size_t) n >= size)
+		return NULL;
+
+	return str;
+}
+
+int
+dc_ble_str2uuid (const char *str, dc_ble_uuid_t uuid)
+{
+	dc_ble_uuid_t tmp = {0};
+
+	if (str == NULL || uuid == NULL)
+		return 0;
+
+	unsigned int i = 0;
+	unsigned char c = 0;
+	while ((c = *str++) != '\0') {
+		if (c == '-') {
+			if (i != 8 && i != 12 && i != 16 && i != 20) {
+				return 0; /* Invalid character! */
+			}
+			continue;
+		} else if (c >= '0' && c <= '9') {
+			c -= '0';
+		} else if (c >= 'A' && c <= 'F') {
+			c -= 'A' - 10;
+		} else if (c >= 'a' && c <= 'f') {
+			c -= 'a' - 10;
+		} else {
+			return 0; /* Invalid character! */
+		}
+
+		if ((i & 1) == 0) {
+			c <<= 4;
+		}
+
+		if (i >= 2 * sizeof(tmp)) {
+			return 0; /* Too many characters! */
+		}
+
+		tmp[i / 2] |= c;
+		i++;
+	}
+
+	if (i != 2 * sizeof(tmp)) {
+		return 0; /* Not enough characters! */
+	}
+
+	memcpy (uuid, tmp, sizeof(tmp));
+
+	return 1;
+}

--- a/src/cressi_goa.c
+++ b/src/cressi_goa.c
@@ -414,6 +414,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 	logbook = dc_buffer_new(4096);
 	if (logbook == NULL) {
 		ERROR (abstract->context, "Failed to allocate memory.");
+		status = DC_STATUS_NOMEMORY;
 		goto error_exit;
 	}
 
@@ -455,6 +456,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 	dive = dc_buffer_new(4096);
 	if (dive == NULL) {
 		ERROR (abstract->context, "Failed to allocate memory.");
+		status = DC_STATUS_NOMEMORY;
 		goto error_free_logbook;
 	}
 

--- a/src/cressi_goa.c
+++ b/src/cressi_goa.c
@@ -34,11 +34,12 @@
 
 #define ISINSTANCE(device) dc_device_isinstance((device), &cressi_goa_device_vtable)
 
-#define CMD_VERSION 0x00
-#define CMD_SET_TIME 0x13
-#define CMD_EXIT_PCLINK 0x1D
-#define CMD_LOGBOOK 0x21
-#define CMD_DIVE    0x22
+#define CMD_VERSION        0x00
+#define CMD_SET_TIME       0x13
+#define CMD_EXIT_PCLINK    0x1D
+#define CMD_LOGBOOK        0x21
+#define CMD_DIVE           0x22
+#define CMD_LOGBOOK_V4     0x23
 
 #define CMD_LOGBOOK_BLE 0x02
 #define CMD_DIVE_BLE    0x03
@@ -49,10 +50,8 @@
 #define ACK     0x06
 
 #define SZ_DATA   512
-#define SZ_PACKET 10
-#define SZ_HEADER 23
+#define SZ_PACKET 12
 
-#define FP_OFFSET 0x11
 #define FP_SIZE   6
 
 #define NSTEPS    1000
@@ -63,6 +62,13 @@ typedef struct cressi_goa_device_t {
 	dc_iostream_t *iostream;
 	unsigned char fingerprint[FP_SIZE];
 } cressi_goa_device_t;
+
+typedef struct cressi_goa_conf_t {
+	unsigned int logbook_cmd;
+	unsigned int logbook_len;
+	unsigned int logbook_fp_offset;
+	unsigned int dive_fp_offset;
+} cressi_goa_conf_t;
 
 static dc_status_t cressi_goa_device_set_fingerprint (dc_device_t *abstract, const unsigned char data[], unsigned int size);
 static dc_status_t cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, void *userdata);
@@ -79,6 +85,11 @@ static const dc_device_vtable_t cressi_goa_device_vtable = {
 	cressi_goa_device_foreach, /* foreach */
 	cressi_goa_device_timesync, /* timesync */
 	cressi_goa_device_close /* close */
+};
+
+static const cressi_goa_conf_t version_conf[] = {
+	{ CMD_LOGBOOK,    23, 17, 12 },
+	{ CMD_LOGBOOK_V4, 15,  3,  4 },
 };
 
 static dc_status_t
@@ -128,7 +139,7 @@ cressi_goa_device_send (cressi_goa_device_t *device, unsigned char cmd, const un
 }
 
 static dc_status_t
-cressi_goa_device_receive (cressi_goa_device_t *device, unsigned char data[], unsigned int size)
+cressi_goa_device_receive (cressi_goa_device_t *device, dc_buffer_t *output)
 {
 	dc_status_t status = DC_STATUS_SUCCESS;
 	dc_device_t *abstract = (dc_device_t *) device;
@@ -137,12 +148,15 @@ cressi_goa_device_receive (cressi_goa_device_t *device, unsigned char data[], un
 	unsigned char packet[SZ_PACKET + 8];
 
 	if (transport == DC_TRANSPORT_BLE) {
-		if (size) {
+		if (output) {
 			return DC_STATUS_INVALIDARGS;
 		} else {
 			return DC_STATUS_SUCCESS;
 		}
 	}
+
+	// Clear the output buffer.
+	dc_buffer_clear (output);
 
 	// Read the header of the data packet.
 	status = dc_iostream_read (device->iostream, packet, 4, NULL);
@@ -185,14 +199,11 @@ cressi_goa_device_receive (cressi_goa_device_t *device, unsigned char data[], un
 		return DC_STATUS_PROTOCOL;
 	}
 
-	// Verify the payload length.
-	if (length != size) {
-		ERROR (abstract->context, "Unexpected payload size (%u).", length);
-		return DC_STATUS_PROTOCOL;
-	}
-
-	if (length) {
-		memcpy (data, packet + 5, length);
+	if (length && output) {
+		if (!dc_buffer_append (output, packet + 5, length)) {
+			ERROR (abstract->context, "Could not append received data.");
+			return DC_STATUS_NOMEMORY;
+		}
 	}
 
 	return status;
@@ -332,7 +343,7 @@ static dc_status_t
 cressi_goa_device_transfer (cressi_goa_device_t *device,
                             unsigned char cmd,
                             const unsigned char input[], unsigned int isize,
-                            unsigned char output[], unsigned int osize,
+                            dc_buffer_t *output,
                             dc_buffer_t *buffer,
                             dc_event_progress_t *progress)
 {
@@ -345,7 +356,7 @@ cressi_goa_device_transfer (cressi_goa_device_t *device,
 	}
 
 	// Receive the answer from the dive computer.
-	status = cressi_goa_device_receive (device, output, osize);
+	status = cressi_goa_device_receive (device, output);
 	if (status != DC_STATUS_SUCCESS) {
 		return status;
 	}
@@ -453,8 +464,14 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 	dc_event_progress_t progress = EVENT_PROGRESS_INITIALIZER;
 	device_event_emit (abstract, DC_EVENT_PROGRESS, &progress);
 
+	dc_buffer_t *id = dc_buffer_new(11);
+	if (id == NULL) {
+		ERROR (abstract->context, "Failed to allocate memory for the ID.");
+		status = DC_STATUS_NOMEMORY;
+		goto error_exit;
+	}
+
 	// Read the version information.
-	unsigned char id[9] = {0};
 	if (transport == DC_TRANSPORT_BLE) {
 		/*
 		 * With the BLE communication, there is no variant of the CMD_VERSION
@@ -471,7 +488,6 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 		};
 		const size_t sizes[] = {5, 2, 2};
 
-		unsigned int offset = 0;
 		for (size_t i = 0; i < C_ARRAY_SIZE(characteristics); ++i) {
 			unsigned char request[sizeof(dc_ble_uuid_t) + 5] = {0};
 
@@ -485,48 +501,89 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 				char uuidstr[DC_BLE_UUID_SIZE] = {0};
 				ERROR (abstract->context, "Failed to read the characteristic '%s'.",
 					dc_ble_uuid2str(characteristics[i], uuidstr, sizeof(uuidstr)));
-				goto error_exit;
+				goto error_free_id;
 			}
 
 			// Copy the payload data.
-			memcpy (id + offset, request + sizeof(dc_ble_uuid_t), sizes[i]);
-			offset += sizes[i];
+			if (!dc_buffer_append(id, request + sizeof(dc_ble_uuid_t), sizes[i])) {
+				ERROR (abstract->context, "Insufficient buffer space available.");
+				status = DC_STATUS_NOMEMORY;
+				goto error_free_id;
+			}
 		}
 	} else {
-		status = cressi_goa_device_transfer (device, CMD_VERSION, NULL, 0, id, sizeof(id), NULL, NULL);
+		status = cressi_goa_device_transfer (device, CMD_VERSION, NULL, 0, id, NULL, NULL);
 		if (status != DC_STATUS_SUCCESS) {
 			ERROR (abstract->context, "Failed to read the version information.");
-			goto error_exit;
+			goto error_free_id;
 		}
 	}
 
+	const unsigned char *id_data = dc_buffer_get_data(id);
+	size_t id_size = dc_buffer_get_size(id);
+
+	if (id_size < 9) {
+		ERROR (abstract->context, "Unexpected version length (" DC_PRINTF_SIZE ").", id_size);
+		status = DC_STATUS_DATAFORMAT;
+		goto error_free_id;
+	}
+
+	// Get the device info.
+	unsigned int model = id_data[4];
+	unsigned int firmware = array_uint16_le (id_data + 5);
+	unsigned int serial = array_uint32_le (id_data + 0);
+
+	// Get the data format version.
+	unsigned int version = 0;
+	if (id_size == 11) {
+		version = array_uint16_le (id_data + 9);
+	} else {
+		if (firmware >= 161 && firmware <= 165) {
+			version = 0;
+		} else if (firmware >= 166 && firmware <= 169) {
+			version = 1;
+		} else if (firmware >= 170 && firmware <= 179) {
+			version = 2;
+		} else if (firmware >= 100 && firmware <= 110) {
+			version = 3;
+		} else if (firmware >= 200 && firmware <= 205) {
+			version = 4;
+		} else {
+			ERROR (abstract->context, "Unknown firmware version (%u).", firmware);
+			status = DC_STATUS_DATAFORMAT;
+			goto error_free_id;
+		}
+	}
+
+	const cressi_goa_conf_t *conf = &version_conf[version >= 4];
+
 	// Emit a vendor event.
 	dc_event_vendor_t vendor;
-	vendor.data = id;
-	vendor.size = sizeof (id);
+	vendor.data = id_data;
+	vendor.size = id_size;
 	device_event_emit (abstract, DC_EVENT_VENDOR, &vendor);
 
 	// Emit a device info event.
 	dc_event_devinfo_t devinfo;
-	devinfo.model = id[4];
-	devinfo.firmware = array_uint16_le (id + 5);
-	devinfo.serial = array_uint32_le (id + 0);
+	devinfo.model = model;
+	devinfo.firmware = firmware;
+	devinfo.serial = serial;
 	device_event_emit (abstract, DC_EVENT_DEVINFO, &devinfo);
 
 	// Allocate memory for the logbook data.
 	logbook = dc_buffer_new(4096);
 	if (logbook == NULL) {
-		ERROR (abstract->context, "Failed to allocate memory.");
+		ERROR (abstract->context, "Failed to allocate memory for the logbook.");
 		status = DC_STATUS_NOMEMORY;
-		goto error_exit;
+		goto error_free_id;
 	}
 
 	// Read the logbook data.
 	if (transport == DC_TRANSPORT_BLE) {
 		unsigned char args[] = {0x00};
-		status = cressi_goa_device_transfer (device, CMD_LOGBOOK_BLE, args, sizeof(args), NULL, 0, logbook, &progress);
+		status = cressi_goa_device_transfer (device, CMD_LOGBOOK_BLE, args, sizeof(args), NULL, logbook, &progress);
 	} else {
-		status = cressi_goa_device_transfer (device, CMD_LOGBOOK, NULL, 0, NULL, 0, logbook, &progress);
+		status = cressi_goa_device_transfer (device, conf->logbook_cmd, NULL, 0, NULL, logbook, &progress);
 	}
 	if (status != DC_STATUS_SUCCESS) {
 		ERROR (abstract->context, "Failed to read the logbook data.");
@@ -539,9 +596,9 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 	// Count the number of dives.
 	unsigned int count = 0;
 	unsigned int offset = logbook_size;
-	while (offset >= SZ_HEADER) {
+	while (offset >= conf->logbook_len) {
 		// Move to the start of the logbook entry.
-		offset -= SZ_HEADER;
+		offset -= conf->logbook_len;
 
 		// Get the dive number.
 		unsigned int number= array_uint16_le (logbook_data + offset);
@@ -549,7 +606,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 			break;
 
 		// Compare the fingerprint to identify previously downloaded entries.
-		if (memcmp (logbook_data + offset + FP_OFFSET, device->fingerprint, sizeof(device->fingerprint)) == 0) {
+		if (memcmp (logbook_data + offset + conf->logbook_fp_offset, device->fingerprint, sizeof(device->fingerprint)) == 0) {
 			break;
 		}
 
@@ -563,7 +620,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 	// Allocate memory for the dive data.
 	dive = dc_buffer_new(4096);
 	if (dive == NULL) {
-		ERROR (abstract->context, "Failed to allocate memory.");
+		ERROR (abstract->context, "Failed to allocate memory for the dive.");
 		status = DC_STATUS_NOMEMORY;
 		goto error_free_logbook;
 	}
@@ -572,16 +629,16 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 	offset = logbook_size;
 	for (unsigned int i = 0; i < count; ++i) {
 		// Move to the start of the logbook entry.
-		offset -= SZ_HEADER;
+		offset -= conf->logbook_len;
 
 		// Read the dive data.
 		if (transport == DC_TRANSPORT_BLE) {
 			unsigned char number[2] = {
 				logbook_data[offset + 1],
 				logbook_data[offset + 0]};
-			status = cressi_goa_device_transfer (device, CMD_DIVE_BLE, number, 2, NULL, 0, dive, &progress);
+			status = cressi_goa_device_transfer (device, CMD_DIVE_BLE, number, 2, NULL, dive, &progress);
 		} else {
-			status = cressi_goa_device_transfer (device, CMD_DIVE, logbook_data + offset, 2, NULL, 0, dive, &progress);
+			status = cressi_goa_device_transfer (device, CMD_DIVE, logbook_data + offset, 2, NULL, dive, &progress);
 		}
 		if (status != DC_STATUS_SUCCESS) {
 			ERROR (abstract->context, "Failed to read the dive data.");
@@ -591,12 +648,11 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 		const unsigned char *dive_data = dc_buffer_get_data (dive);
 		size_t dive_size = dc_buffer_get_size (dive);
 
-		// Verify the header in the logbook and dive data are identical.
-		// After the 2 byte dive number, the logbook header has 5 bytes
-		// extra, which are not present in the dive header.
-		if (dive_size < SZ_HEADER - 5 ||
-			memcmp (dive_data + 0, logbook_data + offset + 0, 2) != 0 ||
-			memcmp (dive_data + 2, logbook_data + offset + 7, SZ_HEADER - 7) != 0) {
+		// Verify the dive number and the fingerprint in the logbook and dive
+		// data are identical.
+		if (dive_size < conf->dive_fp_offset + FP_SIZE ||
+			memcmp (dive_data, logbook_data + offset, 2) != 0 ||
+			memcmp (dive_data + conf->dive_fp_offset, logbook_data + offset + conf->logbook_fp_offset, FP_SIZE) != 0) {
 			ERROR (abstract->context, "Unexpected dive header.");
 			status = DC_STATUS_DATAFORMAT;
 			goto error_free_dive;
@@ -608,12 +664,12 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 		// are prepended to the dive data, along with a small header containing
 		// their size.
 		const unsigned char header[] = {
-			sizeof(id),
-			SZ_HEADER,
+			id_size,
+			conf->logbook_len,
 		};
-		unsigned int headersize = sizeof(header) + sizeof(id) + SZ_HEADER;
-		if (!dc_buffer_prepend(dive, logbook_data + offset, SZ_HEADER) ||
-			!dc_buffer_prepend(dive, id, sizeof(id)) ||
+		unsigned int headersize = sizeof(header) + id_size + conf->logbook_len;
+		if (!dc_buffer_prepend(dive, logbook_data + offset, conf->logbook_len) ||
+			!dc_buffer_prepend(dive, id_data, id_size) ||
 			!dc_buffer_prepend(dive, header, sizeof(header))) {
 			ERROR (abstract->context, "Out of memory.");
 			status = DC_STATUS_NOMEMORY;
@@ -623,7 +679,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 		dive_data = dc_buffer_get_data (dive);
 		dive_size = dc_buffer_get_size (dive);
 
-		if (callback && !callback(dive_data, dive_size, dive_data + headersize + FP_OFFSET - 5, sizeof(device->fingerprint), userdata))
+		if (callback && !callback(dive_data, dive_size, dive_data + headersize + conf->dive_fp_offset, sizeof(device->fingerprint), userdata))
 			break;
 	}
 
@@ -631,6 +687,8 @@ error_free_dive:
 	dc_buffer_free(dive);
 error_free_logbook:
 	dc_buffer_free(logbook);
+error_free_id:
+	dc_buffer_free(id);
 error_exit:
 	return status;
 }
@@ -653,7 +711,7 @@ cressi_goa_device_timesync (dc_device_t *abstract, const dc_datetime_t *datetime
 	new_time[4] = datetime->hour;
 	new_time[5] = datetime->minute;
 	new_time[6] = datetime->second;
-	status = cressi_goa_device_transfer (device, CMD_SET_TIME, new_time, sizeof(new_time), NULL, 0, NULL, NULL);
+	status = cressi_goa_device_transfer (device, CMD_SET_TIME, new_time, sizeof(new_time), NULL, NULL, NULL);
 	if (status != DC_STATUS_SUCCESS) {
 		ERROR (abstract->context, "Failed to set the new time.");
 		return status;
@@ -673,7 +731,7 @@ cressi_goa_device_close (dc_device_t *abstract)
 		return DC_STATUS_SUCCESS;
 	}
 
-	status = cressi_goa_device_transfer (device, CMD_EXIT_PCLINK, NULL, 0, NULL, 0, NULL, NULL);
+	status = cressi_goa_device_transfer (device, CMD_EXIT_PCLINK, NULL, 0, NULL, NULL, NULL);
 	if (status != DC_STATUS_SUCCESS) {
 		ERROR (abstract->context, "Failed to exit PC Link.");
 		return status;

--- a/src/cressi_goa.c
+++ b/src/cressi_goa.c
@@ -431,7 +431,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 	// Count the number of dives.
 	unsigned int count = 0;
 	unsigned int offset = logbook_size;
-	while (offset > SZ_HEADER) {
+	while (offset >= SZ_HEADER) {
 		// Move to the start of the logbook entry.
 		offset -= SZ_HEADER;
 

--- a/src/cressi_goa.c
+++ b/src/cressi_goa.c
@@ -548,6 +548,8 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 			version = 3;
 		} else if (firmware >= 200 && firmware <= 205) {
 			version = 4;
+		} else if (firmware >= 300) {
+			version = 5;
 		} else {
 			ERROR (abstract->context, "Unknown firmware version (%u).", firmware);
 			status = DC_STATUS_DATAFORMAT;

--- a/src/cressi_goa.h
+++ b/src/cressi_goa.h
@@ -35,7 +35,7 @@ dc_status_t
 cressi_goa_device_open (dc_device_t **device, dc_context_t *context, dc_iostream_t *iostream);
 
 dc_status_t
-cressi_goa_parser_create (dc_parser_t **parser, dc_context_t *context, const unsigned char data[], size_t size, unsigned int model);
+cressi_goa_parser_create (dc_parser_t **parser, dc_context_t *context, const unsigned char data[], size_t size);
 
 #ifdef __cplusplus
 }

--- a/src/cressi_goa_parser.c
+++ b/src/cressi_goa_parser.c
@@ -40,7 +40,7 @@
 #define FREEDIVE_ADV 5
 
 #define NGASMIXES  3
-#define NVERSIONS  5
+#define NVERSIONS  6
 #define NDIVEMODES 6
 
 #define UNDEFINED 0xFFFFFFFF
@@ -127,6 +127,19 @@ static const cressi_goa_layout_t scuba_nitrox_layout_v4 = {
 	82, /* headersize */
 	10, /* nsamples */
 	2, /* samplerate */
+	4, /* datetime */
+	11, /* divetime */
+	{ 17, 19, 21 }, /* gasmix */
+	23, /* atmospheric */
+	66, /* maxdepth */
+	68, /* avgdepth */
+	70, /* temperature */
+};
+
+static const cressi_goa_layout_t scuba_nitrox_layout_v5 = {
+	83, /* headersize */
+	2, /* nsamples */
+	UNDEFINED, /* samplerate */
 	4, /* datetime */
 	11, /* divetime */
 	{ 17, 19, 21 }, /* gasmix */
@@ -268,6 +281,14 @@ static const cressi_goa_layout_t * const layouts[NVERSIONS][NDIVEMODES] = {
 		NULL, /* UNUSED */
 		&advanced_freedive_layout_v4, /* FREEDIVE_ADV */
 	},
+	{
+		&scuba_nitrox_layout_v5, /* SCUBA */
+		&scuba_nitrox_layout_v5, /* NITROX */
+		&freedive_layout_v4, /* FREEDIVE */
+		&gauge_layout_v4, /* GAUGE */
+		NULL, /* UNUSED */
+		NULL, /* FREEDIVE_ADV */
+	},
 };
 
 static dc_status_t
@@ -313,6 +334,8 @@ cressi_goa_init(cressi_goa_parser_t *parser)
 			version = 3;
 		} else if (firmware >= 200 && firmware <= 205) {
 			version = 4;
+		} else if (firmware >= 300) {
+			version = 5;
 		} else {
 			ERROR (abstract->context, "Unknown firmware version (%u).", firmware);
 			return DC_STATUS_DATAFORMAT;

--- a/src/cressi_goa_parser.c
+++ b/src/cressi_goa_parser.c
@@ -48,7 +48,6 @@ typedef struct cressi_goa_parser_t cressi_goa_parser_t;
 
 struct cressi_goa_parser_t {
 	dc_parser_t base;
-	unsigned int model;
 };
 
 typedef struct cressi_goa_layout_t {
@@ -126,7 +125,7 @@ static const cressi_goa_layout_t layouts[] = {
 };
 
 dc_status_t
-cressi_goa_parser_create (dc_parser_t **out, dc_context_t *context, const unsigned char data[], size_t size, unsigned int model)
+cressi_goa_parser_create (dc_parser_t **out, dc_context_t *context, const unsigned char data[], size_t size)
 {
 	cressi_goa_parser_t *parser = NULL;
 
@@ -139,8 +138,6 @@ cressi_goa_parser_create (dc_parser_t **out, dc_context_t *context, const unsign
 		ERROR (context, "Failed to allocate memory.");
 		return DC_STATUS_NOMEMORY;
 	}
-
-	parser->model = model;
 
 	*out = (dc_parser_t*) parser;
 

--- a/src/cressi_goa_parser.c
+++ b/src/cressi_goa_parser.c
@@ -339,7 +339,21 @@ cressi_goa_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_t c
 			temperature = value;
 			have_temperature = 1;
 		} else if (type == TIME) {
-			time += value;
+			unsigned int surftime = value;
+			if (surftime > interval) {
+				surftime -= interval;
+				time += interval;
+
+				// Time (seconds).
+				sample.time = time * 1000;
+				if (callback) callback (DC_SAMPLE_TIME, &sample, userdata);
+				// Depth (1/10 m).
+				sample.depth = 0.0;
+				if (callback) callback (DC_SAMPLE_DEPTH, &sample, userdata);
+			}
+			time += surftime;
+			depth = 0;
+			complete = 1;
 		}
 
 		if (complete) {

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -346,6 +346,7 @@ static const dc_descriptor_t g_descriptors[] = {
 	{"Cressi", "Donatello",    DC_FAMILY_CRESSI_GOA, 4, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
 	{"Cressi", "Michelangelo", DC_FAMILY_CRESSI_GOA, 5, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
 	{"Cressi", "Neon",     DC_FAMILY_CRESSI_GOA, 9, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
+	{"Cressi", "Nepto",    DC_FAMILY_CRESSI_GOA, 10, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
 	/* Zeagle N2iTiON3 */
 	{"Zeagle",    "N2iTiON3",   DC_FAMILY_ZEAGLE_N2ITION3, 0, DC_TRANSPORT_SERIAL, NULL},
 	{"Apeks",     "Quantum X",  DC_FAMILY_ZEAGLE_N2ITION3, 0, DC_TRANSPORT_SERIAL, NULL},
@@ -913,6 +914,7 @@ dc_filter_cressi (dc_descriptor_t *descriptor, dc_transport_t transport, const v
 		4,  // Donatello
 		5,  // Michelangelo
 		9,  // Neon
+		10, // Nepto
 	};
 
 	if (transport == DC_TRANSPORT_BLE) {

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -343,6 +343,7 @@ static const dc_descriptor_t g_descriptors[] = {
 	/* Cressi Goa */
 	{"Cressi", "Cartesio", DC_FAMILY_CRESSI_GOA, 1, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
 	{"Cressi", "Goa",      DC_FAMILY_CRESSI_GOA, 2, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
+	{"Cressi", "Leonardo 2.0", DC_FAMILY_CRESSI_GOA, 3, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
 	{"Cressi", "Donatello",    DC_FAMILY_CRESSI_GOA, 4, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
 	{"Cressi", "Michelangelo", DC_FAMILY_CRESSI_GOA, 5, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
 	{"Cressi", "Neon",     DC_FAMILY_CRESSI_GOA, 9, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
@@ -911,6 +912,7 @@ dc_filter_cressi (dc_descriptor_t *descriptor, dc_transport_t transport, const v
 	static const unsigned int model[] = {
 		1,  // Cartesio
 		2,  // Goa
+		3,  // Leonardo 2.0
 		4,  // Donatello
 		5,  // Michelangelo
 		9,  // Neon

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -59,6 +59,7 @@ static int dc_filter_deepsix (dc_descriptor_t *descriptor, dc_transport_t transp
 static int dc_filter_deepblu (dc_descriptor_t *descriptor, dc_transport_t transport, const void *userdata);
 static int dc_filter_oceans (dc_descriptor_t *descriptor, dc_transport_t transport, const void *userdata);
 static int dc_filter_divesoft (dc_descriptor_t *descriptor, dc_transport_t transport, const void *userdata);
+static int dc_filter_cressi (dc_descriptor_t *descriptor, dc_transport_t transport, const void *userdata);
 
 static dc_status_t dc_descriptor_iterator_next (dc_iterator_t *iterator, void *item);
 
@@ -340,11 +341,11 @@ static const dc_descriptor_t g_descriptors[] = {
 	{"Cressi", "Newton",   DC_FAMILY_CRESSI_LEONARDO, 5, DC_TRANSPORT_SERIAL, NULL},
 	{"Cressi", "Drake",    DC_FAMILY_CRESSI_LEONARDO, 6, DC_TRANSPORT_SERIAL, NULL},
 	/* Cressi Goa */
-	{"Cressi", "Cartesio", DC_FAMILY_CRESSI_GOA, 1, DC_TRANSPORT_SERIAL, NULL},
-	{"Cressi", "Goa",      DC_FAMILY_CRESSI_GOA, 2, DC_TRANSPORT_SERIAL, NULL},
-	{"Cressi", "Donatello",    DC_FAMILY_CRESSI_GOA, 4, DC_TRANSPORT_SERIAL, NULL},
-	{"Cressi", "Michelangelo", DC_FAMILY_CRESSI_GOA, 5, DC_TRANSPORT_SERIAL, NULL},
-	{"Cressi", "Neon",     DC_FAMILY_CRESSI_GOA, 9, DC_TRANSPORT_SERIAL, NULL},
+	{"Cressi", "Cartesio", DC_FAMILY_CRESSI_GOA, 1, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
+	{"Cressi", "Goa",      DC_FAMILY_CRESSI_GOA, 2, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
+	{"Cressi", "Donatello",    DC_FAMILY_CRESSI_GOA, 4, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
+	{"Cressi", "Michelangelo", DC_FAMILY_CRESSI_GOA, 5, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
+	{"Cressi", "Neon",     DC_FAMILY_CRESSI_GOA, 9, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
 	/* Zeagle N2iTiON3 */
 	{"Zeagle",    "N2iTiON3",   DC_FAMILY_ZEAGLE_N2ITION3, 0, DC_TRANSPORT_SERIAL, NULL},
 	{"Apeks",     "Quantum X",  DC_FAMILY_ZEAGLE_N2ITION3, 0, DC_TRANSPORT_SERIAL, NULL},
@@ -547,6 +548,31 @@ dc_match_number_with_prefix (const void *key, const void *value)
 }
 
 static int
+dc_match_hex_with_prefix (const void *key, const void *value)
+{
+	const char *str = (const char *) key;
+	const char *prefix = *(const char * const *) value;
+
+	size_t n = strlen (prefix);
+
+	if (strncmp (str, prefix, n) != 0) {
+		return 0;
+	}
+
+	while (str[n] != 0) {
+		const char c = str[n];
+		if ((c < '0' || c > '9') &&
+			(c < 'A' || c > 'F') &&
+			(c < 'a' || c > 'f')) {
+			return 0;
+		}
+		n++;
+	}
+
+	return 1;
+}
+
+static int
 dc_match_oceanic (const void *key, const void *value)
 {
 	unsigned int model = *(const unsigned int *) value;
@@ -560,6 +586,20 @@ dc_match_oceanic (const void *key, const void *value)
 	const char *p = prefix;
 
 	return dc_match_number_with_prefix (key, &p);
+}
+
+static int
+dc_match_cressi (const void *key, const void *value)
+{
+	unsigned int model = *(const unsigned int *) value;
+
+	char prefix[16] = {0};
+
+	dc_platform_snprintf(prefix, sizeof(prefix), "%u_", model);
+
+	const char *p = prefix;
+
+	return dc_match_hex_with_prefix (key, &p);
 }
 
 static int
@@ -859,6 +899,24 @@ dc_filter_divesoft (dc_descriptor_t *descriptor, dc_transport_t transport, const
 
 	if (transport == DC_TRANSPORT_BLE) {
 		return DC_FILTER_INTERNAL (userdata, bluetooth, 0, dc_match_prefix);
+	}
+
+	return 1;
+}
+
+static int
+dc_filter_cressi (dc_descriptor_t *descriptor, dc_transport_t transport, const void *userdata)
+{
+	static const unsigned int model[] = {
+		1,  // Cartesio
+		2,  // Goa
+		4,  // Donatello
+		5,  // Michelangelo
+		9,  // Neon
+	};
+
+	if (transport == DC_TRANSPORT_BLE) {
+		return DC_FILTER_INTERNAL (userdata, model, 0, dc_match_cressi);
 	}
 
 	return 1;

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -276,6 +276,7 @@ static const dc_descriptor_t g_descriptors[] = {
 	/* Pelagic I330R */
 	{"Apeks",    "DSX",                 DC_FAMILY_PELAGIC_I330R, 0x4741, DC_TRANSPORT_BLE, dc_filter_oceanic},
 	{"Aqualung", "i330R",               DC_FAMILY_PELAGIC_I330R, 0x4744, DC_TRANSPORT_BLE, dc_filter_oceanic},
+	{"Aqualung", "i330R Console",       DC_FAMILY_PELAGIC_I330R, 0x474D, DC_TRANSPORT_BLE, dc_filter_oceanic},
 	/* Mares Nemo */
 	{"Mares", "Nemo",         DC_FAMILY_MARES_NEMO, 0, DC_TRANSPORT_SERIAL, NULL},
 	{"Mares", "Nemo Steel",   DC_FAMILY_MARES_NEMO, 0, DC_TRANSPORT_SERIAL, NULL},
@@ -763,6 +764,7 @@ dc_filter_oceanic (dc_descriptor_t *descriptor, dc_transport_t transport, const 
 		0x4744, // Aqualung i330R
 		0x4749, // Aqualung i200C
 		0x474B, // Oceanic Geo Air
+		0x474D, // Aqualung i330R Console
 	};
 
 	if (transport == DC_TRANSPORT_BLE) {

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -270,6 +270,7 @@ static const dc_descriptor_t g_descriptors[] = {
 	{"Sherwood", "Amphos Air 2.0",      DC_FAMILY_OCEANIC_ATOM2, 0x4658, DC_TRANSPORT_SERIAL, NULL},
 	{"Sherwood", "Beacon",              DC_FAMILY_OCEANIC_ATOM2, 0x4742, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_oceanic},
 	{"Aqualung", "i470TC",              DC_FAMILY_OCEANIC_ATOM2, 0x4743, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_oceanic},
+	{"Aqualung", "i100",                DC_FAMILY_OCEANIC_ATOM2, 0x4745, DC_TRANSPORT_SERIAL, NULL},
 	{"Aqualung", "i200C",               DC_FAMILY_OCEANIC_ATOM2, 0x4749, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_oceanic},
 	{"Oceanic",  "Geo Air",             DC_FAMILY_OCEANIC_ATOM2, 0x474B, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_oceanic},
 	/* Pelagic I330R */

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -147,6 +147,7 @@ static const dc_descriptor_t g_descriptors[] = {
 	{"Uwatec",   "Galileo Terra",       DC_FAMILY_UWATEC_SMART, 0x11, DC_TRANSPORT_IRDA, dc_filter_uwatec},
 	{"Uwatec",   "Aladin Tec",          DC_FAMILY_UWATEC_SMART, 0x12, DC_TRANSPORT_IRDA, dc_filter_uwatec},
 	{"Uwatec",   "Aladin Prime",        DC_FAMILY_UWATEC_SMART, 0x12, DC_TRANSPORT_IRDA, dc_filter_uwatec},
+	{"Uwatec",   "Aladin One",          DC_FAMILY_UWATEC_SMART, 0x12, DC_TRANSPORT_IRDA, dc_filter_uwatec},
 	{"Uwatec",   "Aladin Tec 2G",       DC_FAMILY_UWATEC_SMART, 0x13, DC_TRANSPORT_IRDA, dc_filter_uwatec},
 	{"Uwatec",   "Aladin 2G",           DC_FAMILY_UWATEC_SMART, 0x13, DC_TRANSPORT_IRDA, dc_filter_uwatec},
 	{"Subgear",  "XP-10",               DC_FAMILY_UWATEC_SMART, 0x13, DC_TRANSPORT_IRDA, dc_filter_uwatec},

--- a/src/libdivecomputer.symbols
+++ b/src/libdivecomputer.symbols
@@ -66,6 +66,9 @@ dc_bluetooth_device_free
 dc_bluetooth_iterator_new
 dc_bluetooth_open
 
+dc_ble_uuid2str
+dc_ble_str2uuid
+
 dc_irda_device_get_address
 dc_irda_device_get_name
 dc_irda_device_free

--- a/src/oceanic_atom2.c
+++ b/src/oceanic_atom2.c
@@ -513,6 +513,7 @@ static const oceanic_common_version_t versions[] = {
 	{"AERISAIR \0\0 1024", 0,      A300AI,        &oceanic_vt4_layout},
 	{"SWVISION \0\0 1024", 0,      VISION,        &oceanic_vt4_layout},
 	{"XPSUBAIR \0\0 1024", 0,      XPAIR,         &oceanic_vt4_layout},
+	{"AQUAI100 \0\0 1024", 0,      I100V2,        &oceanic_vt4_layout},
 
 	{"HOLLDG04 \0\0 2048", 0,      TX1,           &hollis_tx1_layout},
 

--- a/src/oceanic_atom2_parser.c
+++ b/src/oceanic_atom2_parser.c
@@ -142,7 +142,7 @@ oceanic_atom2_parser_create (dc_parser_t **out, dc_context_t *context, const uns
 	} else if (model == PROPLUSX) {
 		parser->headersize = 3 * PAGESIZE;
 	} else if (model == I550C || model == WISDOM4 ||
-		model == I200CV2) {
+		model == I200CV2|| model == I100V2) {
 		parser->headersize = 5 * PAGESIZE / 2;
 	} else if (model == I330R) {
 		parser->logbooksize = 64;
@@ -221,6 +221,7 @@ oceanic_atom2_parser_get_datetime (dc_parser_t *abstract, dc_datetime_t *datetim
 		case I470TC:
 		case I200CV2:
 		case GEOAIR:
+		case I100V2:
 			datetime->year   = ((p[5] & 0xE0) >> 5) + ((p[7] & 0xE0) >> 2) + 2000;
 			datetime->month  = (p[3] & 0x0F);
 			datetime->day    = ((p[0] & 0x80) >> 3) + ((p[3] & 0xF0) >> 4);
@@ -728,7 +729,7 @@ oceanic_atom2_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_
 		parser->model == I300C || parser->model == TALIS ||
 		parser->model == I200C || parser->model == I200CV2 ||
 		parser->model == GEO40 || parser->model == VEO40 ||
-		parser->model == I330R) {
+		parser->model == I330R || parser->model == I100V2) {
 		have_pressure = 0;
 	}
 
@@ -883,7 +884,7 @@ oceanic_atom2_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_
 					parser->model == I300C || parser->model == I200C ||
 					parser->model == GEO40 || parser->model == VEO40 ||
 					parser->model == I470TC || parser->model == I200CV2 ||
-					parser->model == GEOAIR) {
+					parser->model == GEOAIR || parser->model == I100V2) {
 					temperature = data[offset + 3];
 				} else if (parser->model == OCS || parser->model == TX1) {
 					temperature = data[offset + 1];
@@ -976,7 +977,7 @@ oceanic_atom2_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_
 				parser->model == I300C || parser->model == I200C ||
 				parser->model == GEO40 || parser->model == VEO40 ||
 				parser->model == I470TC || parser->model == I200CV2 ||
-				parser->model == GEOAIR)
+				parser->model == GEOAIR || parser->model == I100V2)
 				depth = (data[offset + 4] + (data[offset + 5] << 8)) & 0x0FFF;
 			else if (parser->model == I330R || parser->model == DSX)
 				depth = array_uint16_le (data + offset + 2);
@@ -1043,7 +1044,7 @@ oceanic_atom2_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_
 				parser->model == I450T || parser->model == I200C ||
 				parser->model == GEO40 || parser->model == VEO40 ||
 				parser->model == I470TC || parser->model == I200CV2 ||
-				parser->model == GEOAIR) {
+				parser->model == GEOAIR || parser->model == I100V2) {
 				decostop = (data[offset + 7] & 0xF0) >> 4;
 				decotime = array_uint16_le(data + offset + 6) & 0x0FFF;
 				have_deco = 1;

--- a/src/oceanic_common.h
+++ b/src/oceanic_common.h
@@ -122,6 +122,7 @@ extern "C" {
 #define AMPHOSAIR2    0x4658
 #define BEACON        0x4742
 #define I470TC        0x4743
+#define I100V2        0x4745
 #define I200CV2       0x4749
 #define GEOAIR        0x474B
 

--- a/src/oceanic_common.h
+++ b/src/oceanic_common.h
@@ -129,6 +129,7 @@ extern "C" {
 // i330r
 #define DSX           0x4741
 #define I330R         0x4744
+#define I330R_C       0x474D
 
 #define PAGESIZE 0x10
 #define FPMAXSIZE 0x200

--- a/src/parser.c
+++ b/src/parser.c
@@ -155,7 +155,7 @@ dc_parser_new_internal (dc_parser_t **out, dc_context_t *context, const unsigned
 		rc = cressi_leonardo_parser_create (&parser, context, data, size, model);
 		break;
 	case DC_FAMILY_CRESSI_GOA:
-		rc = cressi_goa_parser_create (&parser, context, data, size, model);
+		rc = cressi_goa_parser_create (&parser, context, data, size);
 		break;
 	case DC_FAMILY_ATOMICS_COBALT:
 		rc = atomics_cobalt_parser_create (&parser, context, data, size);

--- a/src/shearwater_common.c
+++ b/src/shearwater_common.c
@@ -728,6 +728,7 @@ shearwater_common_get_model (shearwater_common_device_t *device, unsigned int ha
 		model = PERDIXAI;
 		break;
 	case 0xC407:
+	case 0xC964:
 		model = PERDIX2;
 		break;
 	case 0x0F0F:


### PR DESCRIPTION
Add the latest updates in libdivecomputer as of 2024/12/31:

- **Add support for a new variant of the Aqualung i100**
- **Add a new Perdix 2 hardware ID**
- **Add support for the i330R Console**
- **Return the correct error code**
- **Don't skip the last entry in the logbook buffer**
- **Add ioctl's for reading and writing BLE characteristics**
- **Add helper functions to convert UUID to/from strings**
- **Add support for the Cressi BLE protocol variant**
- **Remove the unused model parameter**
- **Add the device id and logbook entry**
- **Add an extra surface sample**
- **Add timesync support**
- **Exit PC Link mode when operation is done**
- **Add support for the Cressi Nepto**
- **Add support for the Cressi Leonardo 2.0**
- **Add CCR support for the Excursion**
- **Add support for the Uwatec Aladin One**
