### PR TITLE
Garmin: Remove File Name from File Data.

### DIFF
--- a/src/garmin.c
+++ b/src/garmin.c
@@ -558,7 +558,6 @@ garmin_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, void 
 
 		// Reset the membuffer, read the data
 		dc_buffer_clear(file);
-		dc_buffer_append(file, name, FIT_NAME_SIZE);
 #ifdef HAVE_LIBMTP
 		if (device->use_mtp)
 			status = mtp_read_file(device, files.array[i].mtp_id, file);


### PR DESCRIPTION
Remove the file name from the beginning of the file data buffer. This is
in preparation to a move to shift the .FIT file importer to 'Import log
files'.
The file name in the buffer does not seem to be used for anything, and
it seems to be wrong to have this added only for the parser to then have
to remove this non-file-content again first thing.
Fingerprinting has been confirmed as working after this change.

@torvalds, @dirkhh: As the original creators of the Garmin importer, do you know if there are any hidden reasons to have the file name included in the file content buffer?

Signed-off-by: Michael Keller <github@ike.ch>
