### PR TITLE
Garmin: Add the Descent X50i to the List of Recognised Devices.

### DIFF
--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -493,7 +493,7 @@ static const dc_descriptor_t g_descriptors[] = {
 	/* for the Mk2/Mk3 we are using the model of the Mk2 global model */
 	/* see garmin_parser.c for a more comprehensive list of models */
 	{"Garmin", "Descent Mk1", DC_FAMILY_GARMIN, 2859, DC_TRANSPORT_USBSTORAGE, NULL},
-	{"Garmin", "Descent Mk2(i)/Mk3(i)", DC_FAMILY_GARMIN, 3258, DC_TRANSPORT_USBSTORAGE, NULL},
+	{"Garmin", "Descent Mk2(i)/Mk3(i)(S)/G1/G2/X50i", DC_FAMILY_GARMIN, 3258, DC_TRANSPORT_USBSTORAGE, NULL},
 	{"FIT", "File import", DC_FAMILY_GARMIN, 0, DC_TRANSPORT_USBSTORAGE, NULL },
 };
 

--- a/src/garmin_parser.c
+++ b/src/garmin_parser.c
@@ -1648,18 +1648,23 @@ static void add_sensor_string(garmin_parser_t *garmin, const char *desc, const s
 static dc_status_t
 garmin_parser_set_data (garmin_parser_t *garmin, const unsigned char *data, unsigned int size)
 {
-	// This list is empirical and somewhat speculative
-	// will have to be confirmed with Garmin
+	// Ids can be found at https://developer.garmin.com/connect-iq/reference-guides/devices-reference/
+	// (look for 'Part Number')
 	static const struct {
-		int id;
 		const char *name;
+		int id;
 	} models[] = {
-		{ 2859, "Descent Mk1" },
-		{ 2991, "Descent Mk1 APAC" },
-		{ 3258, "Descent Mk2(i)" },
-		{ 3542, "Descent Mk2s" },
-		{ 3702, "Descent Mk2 APAC" },
-		{ 4223, "Descent Mk3" },
+		{ "Descent™ G1 / G1 Solar", 4005 },
+		{ "Descent™ G2", 4588 },
+		{ "Descent™ Mk1", 2859 },
+		{ "Descent™ Mk1 APAC", 2991 },
+		{ "Descent™ Mk2(i)", 3258 },
+		{ "Descent™ Mk2(i) APAC", 3702 },
+		{ "Descent™ Mk2 S", 3542 },
+		{ "Descent™ Mk2 S APAC", 3930 },
+		{ "Descent™ Mk3(i) 43mm", 4222 },
+		{ "Descent™ Mk3(i) 51mm", 4223 },
+		{ "Descent™ X50i", 4518 },
 	};
 
 	/* Walk the data once without a callback to set up the core fields */


### PR DESCRIPTION
Also add device ids for the rest of the Descent family, according to
data in https://developer.garmin.com/connect-iq/reference-guides/devices-reference/

![Screenshot From 2025-03-14 14-04-01](https://github.com/user-attachments/assets/015bfbac-b41f-4614-8c99-cfbae5736f1b)

![Screenshot From 2025-03-14 14-04-27](https://github.com/user-attachments/assets/0fd1f9cc-63b0-43b8-a30c-d3605023f671)


From discussion: https://groups.google.com/g/subsurface-divelog/c/FTZGTzVgLyo/m/iq5FAr0zAAAJ

Thanks to Christian Froidevaux for providing the X50i sample files.