### PR TITLE
Add support for a new Sirius profile version

### DIFF
--- a/src/mares_iconhd_parser.c
+++ b/src/mares_iconhd_parser.c
@@ -1071,7 +1071,7 @@ mares_genius_foreach (dc_parser_t *abstract, dc_sample_callback_t callback, void
 	unsigned int profile_minor = data[offset + 2];
 	unsigned int profile_major = data[offset + 3];
 	if (profile_type > 1 ||
-		(profile_type == 0 && OBJVERSION(profile_major,profile_minor) > OBJVERSION(1,0)) ||
+		(profile_type == 0 && OBJVERSION(profile_major,profile_minor) > OBJVERSION(2,0)) ||
 		(profile_type == 1 && OBJVERSION(profile_major,profile_minor) > OBJVERSION(0,2))) {
 		ERROR (abstract->context, "Unsupported object type (%u) or version (%u.%u).",
 			profile_type, profile_major, profile_minor);


### PR DESCRIPTION
After upgrading a Mares Sirius to firmware version 1.6.16, the profile
version changed to v2.0. Surprisingly, despite the change in the major
version number, there appear to be no functional changes in the data
format.

Signed-off-by: rmultan <multan.rafal.k@gmail.com>
(cherry picked from commit 82712ce8f83b2448d01ad26a949a82c27452ba5d)
