### PR TITLE
Fix Scubapro Luna 2.0 sample interval to display correct dive duration.

### DIFF
--- a/src/uwatec_smart_parser.c
+++ b/src/uwatec_smart_parser.c
@@ -916,6 +916,11 @@ uwatec_smart_parse (uwatec_smart_parser_t *parser, dc_sample_callback_t callback
 	double density = (parser->watertype == DC_WATER_SALT ? SALT : FRESH);
 
 	unsigned int interval = 4;
+	
+	if (parser->model == LUNA2) {
+		interval = 2;
+	}
+	
 	if (parser->divemode == DC_DIVEMODE_FREEDIVE) {
 		interval = 1;
 	}


### PR DESCRIPTION
With this fix dives imported from Scubapro Luna 2.0 to Subsurface-mobile will display correct dive durations. With default interval of 4, dive durations will be twice as long as they should be. Reducing interval to 2 fixes this.
