### PR TITLE
Heinrichs Weikamp: Add Placeholder for GPS Coordinates on OSTC5

### DIFF
--- a/src/hw_ostc_parser.c
+++ b/src/hw_ostc_parser.c
@@ -1226,9 +1226,9 @@ hw_ostc_parser_internal_foreach (hw_ostc_parser_t *parser, dc_sample_callback_t 
 				}
 
 				coordinate_value_t lon;
-				lon.intval = (float)array_uint32_le(data + offset); // Longitude
+				lon.intval = array_uint32_le(data + offset); // Longitude
 				coordinate_value_t lat;
-				lat.intval = (float)array_uint32_le(data + offset + 4); // Latitude
+				lat.intval = array_uint32_le(data + offset + 4); // Latitude
 
 				INFO(abstract->context, "Received GPS coordinates %f / %f", lat.floatval, lon.floatval);
 

--- a/src/hw_ostc_parser.c
+++ b/src/hw_ostc_parser.c
@@ -153,6 +153,11 @@ typedef struct hw_ostc_parser_t {
 	bool scrubber_warning_reported;
 } hw_ostc_parser_t;
 
+typedef union {
+	unsigned int intval;
+	float floatval;
+} coordinate_value_t;
+
 static dc_status_t hw_ostc_parser_get_datetime (dc_parser_t *abstract, dc_datetime_t *datetime);
 static dc_status_t hw_ostc_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigned int flags, void *value);
 static dc_status_t hw_ostc_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_t callback, void *userdata);
@@ -1213,12 +1218,19 @@ hw_ostc_parser_internal_foreach (hw_ostc_parser_t *parser, dc_sample_callback_t 
 				length -= 2;
 			}
 
-			// GNSS position
+			// GNSS position update (placeholder for now)
 			if (events & 0x0400) {
 				if (length < 8) {
-					ERROR (abstract->context, "Buffer overflow detected!");
+					ERROR (abstract->context, "Buffer underflow detected!");
 					return DC_STATUS_DATAFORMAT;
 				}
+
+				coordinate_value_t lon;
+				lon.intval = (float)array_uint32_le(data + offset); // Longitude
+				coordinate_value_t lat;
+				lat.intval = (float)array_uint32_le(data + offset + 4); // Latitude
+
+				INFO(abstract->context, "Received GPS coordinates %f / %f", lat.floatval, lon.floatval);
 
 				offset += 8;
 				length -= 8;


### PR DESCRIPTION
Add a placeholder for the yet to be added GPS coordinates on OSTC5. This
fixes the misalignment of the parsed data when the log was generated by
firmware with GPS support.

Signed-off-by: Michael Keller <github@ike.ch>
