### PR TITLE
Fix TTS Reporting.

### DIFF
--- a/src/deepsix_excursion_parser.c
+++ b/src/deepsix_excursion_parser.c
@@ -752,6 +752,7 @@ deepsix_excursion_parser_samples_foreach_v1 (dc_parser_t *abstract, dc_sample_ca
 						sample.deco.depth = 0;
 						sample.deco.time = deco_ndl_tts;
 					}
+					sample.deco.tts = 0;
 					if (callback) callback (DC_SAMPLE_DECO, &sample, userdata);
 					break;
 				default:

--- a/src/garmin_parser.c
+++ b/src/garmin_parser.c
@@ -297,6 +297,7 @@ static void flush_pending_record(struct garmin_parser_t *garmin)
 		sample.deco.type = DC_DECO_DECOSTOP;
 		sample.deco.time = record->stop_time;
 		sample.deco.depth = record->ceiling;
+		sample.deco.tts = 0;
 		garmin->callback(DC_SAMPLE_DECO, &sample, garmin->userdata);
 	}
 
@@ -581,6 +582,7 @@ DECLARE_FIELD(RECORD, ndl, UINT32)			// s
 		dc_sample_value_t sample = {0};
 		sample.deco.type = DC_DECO_NDL;
 		sample.deco.time = data;
+		sample.deco.tts = 0;
 		garmin->callback(DC_SAMPLE_DECO, &sample, garmin->userdata);
 	}
 }


### PR DESCRIPTION
Fix the reporting of TTS (Time To Surface) on a number of dive computers.
Report '0' (TTS not known) instead of an arbitrary number when building
on Fedora.

Signed-off-by: Michael Keller <github@ike.ch>
