### PR TITLE
Separate the Reporting of 'bearing' vs. 'heading.

### DIFF
--- a/src/hw_ostc_parser.c
+++ b/src/hw_ostc_parser.c
@@ -1184,7 +1184,6 @@ hw_ostc_parser_internal_foreach (hw_ostc_parser_t *parser, dc_sample_callback_t 
 
 				if (callback) {
 					unsigned int value = array_uint16_le(data + offset);
-					dc_sample_type_t eventType = DC_SAMPLE_EVENT;
 					dc_sample_value_t sample = {
 						.event.type = SAMPLE_EVENT_STRING,
 						.event.flags = SAMPLE_FLAGS_SEVERITY_INFO,
@@ -1194,13 +1193,12 @@ hw_ostc_parser_internal_foreach (hw_ostc_parser_t *parser, dc_sample_callback_t 
 					if (value & OSTC4_COMPASS_HEADING_CLEARED_FLAG) {
 						snprintf(buf, BUFLEN, "Cleared compass heading");
 					} else {
+						sample.event.value = heading;
 
 						if (value & OSTC4_COMPASS_HEADING_SET_FLAG) {
-							eventType = DC_SAMPLE_BEARING;
-							sample.bearing = heading;
+							sample.event.type = SAMPLE_EVENT_HEADING;
 							snprintf(buf, BUFLEN, "Set compass heading [degrees]%s", sample.event.value ? "" : ": 0");
 						} else {
-							sample.event.value = heading;
 							snprintf(buf, BUFLEN, "Logged compass heading [degrees]%s", sample.event.value ? "" : ": 0");
 						}
 
@@ -1208,7 +1206,7 @@ hw_ostc_parser_internal_foreach (hw_ostc_parser_t *parser, dc_sample_callback_t 
 
 					sample.event.name = buf;
 
-					callback(eventType, &sample, userdata);
+					callback(DC_SAMPLE_EVENT, &sample, userdata);
 				}
 
 				offset += 2;

--- a/src/uwatec_smart_parser.c
+++ b/src/uwatec_smart_parser.c
@@ -1192,8 +1192,13 @@ uwatec_smart_parse (uwatec_smart_parser_t *parser, dc_sample_callback_t callback
 			}
 
 			if (have_bearing) {
-				sample.bearing = bearing;
-				if (callback) callback (DC_SAMPLE_BEARING, &sample, userdata);
+				sample.event.type = SAMPLE_EVENT_HEADING;
+				sample.event.time = 0;
+				sample.event.flags = SAMPLE_FLAGS_SEVERITY_INFO;
+				sample.event.value = bearing;
+				sample.event.name = NULL;
+
+				if (callback) callback(DC_SAMPLE_EVENT, &sample, userdata);
 				have_bearing = 0;
 			}
 


### PR DESCRIPTION
There seems to be two different ways that dive computers report
directional information:

1. report headings that are set by the user by pointing the device in
   the desired direction, then pressing a button;

2. report the direction that the device is pointing in at set intervals
   (like every 10 seconds) during the dive.

For a user-friendly visualisation, these two approaches need to be shown
in different ways in Subsurface:

1. show an event in the profile every time the user executes the 'set
   heading' operation (and potentially at the start of the dive for the
   initial heading):

<img width="719" height="499" alt="image" src="https://github.com/user-attachments/assets/21396293-0a63-4dd6-8652-d47fb1ad75e6" />

2. show the current bearing in the information box in the profile when
   the mouse pointer traverses the profile:

<img width="714" height="492" alt="image" src="https://github.com/user-attachments/assets/13b9c7f5-bbd8-45c2-b069-f2da1576732e" />

Subsurface will be using different ways for libdivecomputer backends to
import this data:

1. using `DC_SAMPLE_EVENT` samples with `SAMPLE_EVENT_HEADING` type;

2. using `DC_SAMPLE_BEARING` samples.

This changeset updates the following dive computers to use 1. to match
their type of reporting:

- Heinrichs Weikamp OSTC3 / 4 / 5
- ScubaPro / Uwatec Smart

The following dive computers are already using 1. correctly:

- Suunto EON Steel
- Suunto D9

And the following dive computer seems to be using 2. correctly:

- Divesoft Freedom / Liberty (@jakubhecko are you able to confirm this?)

The following dive computers are currently using 2., but we don't have
any information if this is correct:

- DiveSystem iDive
- Shearwater Predator
- Halcyon Symbios

Signed-off-by: Michael Keller <github@ike.ch>
