### PR TITLE
Garmin: Add Timezone Offset Information to Extra Info.

### DIFF
--- a/src/garmin_parser.c
+++ b/src/garmin_parser.c
@@ -1749,8 +1749,10 @@ garmin_parser_get_datetime (dc_parser_t *abstract, dc_datetime_t *datetime)
 		/* 15-minute (900-second) offsets are real */
 		if ((offset % 900) == 0 &&
 		    offset >= -12*60*60 &&
-		    offset <= 14*60*60)
+		    offset <= 14*60*60) {
 			timezone = offset;
+			dc_field_add_string_fmt(&garmin->cache, "Time offset from UTC [s]", "%+d", offset);
+		}
 	}
 	datetime->timezone = timezone;
 


### PR DESCRIPTION
Add the offset of the reported dive time to UTC as an Extra Info field.

Note that the same offset can also be extracted from the `timezone` field
that is returned by `dc_parser_get_datetime()`.

<img width="297" height="40" alt="image" src="https://github.com/user-attachments/assets/1d6aef91-356b-4afc-8b32-bd7839b7ada4" />
