### PR TITLE
Garmin: Standardise the Firmware Version Reporting.

### DIFF
--- a/include/libdivecomputer/parser.h
+++ b/include/libdivecomputer/parser.h
@@ -109,6 +109,7 @@ typedef enum parser_sample_event_t {
 #define SAMPLE_EVENT_STRING SAMPLE_EVENT_STRING
 
 #define STRING_KEY_FIRMWARE_VERSION "FW Version"
+#define STRING_KEY_SERIAL_NUMBER "Serial"
 
 /* For backwards compatibility */
 #define SAMPLE_EVENT_UNKNOWN SAMPLE_EVENT_FLOOR

--- a/include/libdivecomputer/parser.h
+++ b/include/libdivecomputer/parser.h
@@ -108,6 +108,8 @@ typedef enum parser_sample_event_t {
 /* To let the compile know we have this */
 #define SAMPLE_EVENT_STRING SAMPLE_EVENT_STRING
 
+#define STRING_KEY_FIRMWARE_VERSION "FW Version"
+
 /* For backwards compatibility */
 #define SAMPLE_EVENT_UNKNOWN SAMPLE_EVENT_FLOOR
 

--- a/src/atomics_cobalt_parser.c
+++ b/src/atomics_cobalt_parser.c
@@ -212,7 +212,7 @@ atomics_cobalt_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, un
 		case DC_FIELD_STRING:
 			switch(flags) {
 			case 0: // Serialnr
-				string->desc = "Serial";
+				string->desc = STRING_KEY_SERIAL_NUMBER;
 				snprintf(buf, BUFLEN, "%c%c%c%c-%c%c%c%c", p[4], p[5], p[6], p[7], p[8], p[9], p[10], p[11]);
 				break;
 			case 1: // Program Version

--- a/src/garmin_parser.c
+++ b/src/garmin_parser.c
@@ -1663,7 +1663,7 @@ garmin_parser_set_data (garmin_parser_t *garmin, const unsigned char *data, unsi
 	if (garmin->dive.serial)
 		dc_field_add_string_fmt(&garmin->cache, "Serial", "%u", garmin->dive.serial);
 	if (garmin->dive.firmware)
-		dc_field_add_string_fmt(&garmin->cache, "Firmware", "%u.%02u",
+		dc_field_add_string_fmt(&garmin->cache, STRING_KEY_FIRMWARE_VERSION, "%u.%02u",
 			garmin->dive.firmware / 100, garmin->dive.firmware % 100);
 	if (garmin->dive.product) {
 		unsigned i;

--- a/src/garmin_parser.c
+++ b/src/garmin_parser.c
@@ -1661,7 +1661,7 @@ garmin_parser_set_data (garmin_parser_t *garmin, const unsigned char *data, unsi
 
 	// Device information
 	if (garmin->dive.serial)
-		dc_field_add_string_fmt(&garmin->cache, "Serial", "%u", garmin->dive.serial);
+		dc_field_add_string_fmt(&garmin->cache, STRING_KEY_SERIAL_NUMBER, "%u", garmin->dive.serial);
 	if (garmin->dive.firmware)
 		dc_field_add_string_fmt(&garmin->cache, STRING_KEY_FIRMWARE_VERSION, "%u.%02u",
 			garmin->dive.firmware / 100, garmin->dive.firmware % 100);

--- a/src/hw_ostc_parser.c
+++ b/src/hw_ostc_parser.c
@@ -751,7 +751,7 @@ hw_ostc_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigned 
 		case DC_FIELD_STRING:
 			switch(flags) {
 			case 0: /* serial */
-				string->desc = "Serial";
+				string->desc = STRING_KEY_SERIAL_NUMBER;
 				snprintf(buf, BUFLEN, "%u", parser->serial);
 				break;
 			case 1: /* battery */

--- a/src/hw_ostc_parser.c
+++ b/src/hw_ostc_parser.c
@@ -772,7 +772,7 @@ hw_ostc_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigned 
 						 array_uint16_le (data + layout->desat) % 60);
 				break;
 			case 3: /* firmware */
-				string->desc = "FW Version";
+				string->desc = STRING_KEY_FIRMWARE_VERSION;
 				/* OSTC4 stores firmware as XXXX XYYY YYZZ ZZZB, -> X.Y.Z beta? */
 				if (parser->model == OSTC4) {
 					int firmwareOnDevice = array_uint16_le (data + layout->firmware);

--- a/src/mares_iconhd_parser.c
+++ b/src/mares_iconhd_parser.c
@@ -907,7 +907,7 @@ mares_iconhd_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsi
 		case DC_FIELD_STRING:
 			switch(flags) {
 			case 0: /* serial */
-				string->desc = "Serial";
+				string->desc = STRING_KEY_SERIAL_NUMBER;
 				snprintf(buf, BUFLEN, "%u", parser->serial);
 				break;
 			default:

--- a/src/oceanic_atom2_parser.c
+++ b/src/oceanic_atom2_parser.c
@@ -626,7 +626,7 @@ oceanic_atom2_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, uns
 		case DC_FIELD_STRING:
 			switch(flags) {
 			case 0: /* Serial */
-				string->desc = "Serial";
+				string->desc = STRING_KEY_SERIAL_NUMBER;
 				snprintf(buf, BUF_LEN, "%06u", parser->serial);
 				break;
 			default:

--- a/src/shearwater_predator_parser.c
+++ b/src/shearwater_predator_parser.c
@@ -893,7 +893,7 @@ shearwater_predator_parser_cache (shearwater_predator_parser_t *parser)
 
 	dc_field_add_string_fmt(&parser->cache, "Serial", "%08x", parser->serial);
 	// bytes 1-31 are identical in all formats
-	dc_field_add_string_fmt(&parser->cache, "FW Version", "%2x", data[19]);
+	dc_field_add_string_fmt(&parser->cache, STRING_KEY_FIRMWARE_VERSION, "%2x", data[19]);
 	add_deco_model(parser, data);
 	add_battery_type(parser, data);
 	dc_field_add_string_fmt(&parser->cache, "Battery at end", "%.1f V", data[9] / 10.0);

--- a/src/suunto_d9_parser.c
+++ b/src/suunto_d9_parser.c
@@ -414,7 +414,7 @@ suunto_d9_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigne
 		case DC_FIELD_STRING:
 			switch (flags) {
 			case 0: /* serial */
-				string->desc = "Serial";
+				string->desc = STRING_KEY_SERIAL_NUMBER;
 				snprintf(buf, BUFLEN, "%08u", parser->serial);
 				break;
 			default:

--- a/src/suunto_eonsteel_parser.c
+++ b/src/suunto_eonsteel_parser.c
@@ -1208,7 +1208,7 @@ static dc_status_t traverse_device_fields(suunto_eonsteel_parser_t *eon,
 	if (!strcmp(name, "Info.HW"))
 		return dc_field_add_string(&eon->cache, "HW Version", data);
 	if (!strcmp(name, "Info.SW"))
-		return dc_field_add_string(&eon->cache, "FW Version", data);
+		return dc_field_add_string(&eon->cache, STRING_KEY_FIRMWARE_VERSION, data);
 	if (!strcmp(name, "Info.BatteryAtStart"))
 		return dc_field_add_string(&eon->cache, "Battery at start", data);
 	if (!strcmp(name, "Info.BatteryAtEnd"))

--- a/src/suunto_vyper_parser.c
+++ b/src/suunto_vyper_parser.c
@@ -296,7 +296,7 @@ suunto_vyper_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsi
 		case DC_FIELD_STRING:
 			switch(flags) {
 			case 0: /* serial */
-				string->desc = "Serial";
+				string->desc = STRING_KEY_SERIAL_NUMBER;
 				snprintf(buf, BUFLEN, "%u", parser->serial);
 				break;
 			default:


### PR DESCRIPTION
Standardise on 'FW Version' as the Extra Info key to report the firmware
under, because Subsurface is using this key to look up the firmware
version.

Signed-off-by: Michael Keller <github@ike.ch>
