### PR TITLE
Garmin: Add Suppport for the fenix 8 Family of Devices.

### DIFF
--- a/src/garmin.c
+++ b/src/garmin.c
@@ -84,7 +84,7 @@ typedef struct garmin_device_t {
 #endif
 } garmin_device_t;
 
-// Ids can be found at https://developer.garmin.com/connect-iq/reference-guides/devices-reference/
+// Ids can be found at https://developer.garmin.com/connect-iq/device-reference/
 // (look for 'Part Number')
 
 const garmin_model_t garmin_models[] = {
@@ -99,6 +99,13 @@ const garmin_model_t garmin_models[] = {
 	{ "Descent™ Mk3(i) 43mm", 4222, true },
 	{ "Descent™ Mk3(i) 51mm", 4223, true },
 	{ "Descent™ X50i", 4518, true },
+	{ "fēnix® 8 43mm", 4534, true },
+	{ "fēnix® 8 47mm / 51mm / tactix® 8 47mm / 51mm / quatix® 8 47mm / 51mm APAC", 4536, true },
+	{ "fēnix® 8 47mm / 51mm / tactix® 8 47mm / 51mm / quatix® 8 47mm / 51mm", 4775, true },
+	{ "fēnix® 8 Pro 47mm / 51mm / MicroLED / quatix® 8 Pro 47mm / 51mm", 4631, true },
+	{ "fēnix® 8 Solar 47mm", 4532, true },
+	{ "fēnix® 8 Solar 51mm / tactix® 8 Solar 51mm APAC", 4533, true },
+	{ "fēnix® 8 Solar 51mm / tactix® 8 Solar 51mm", 4776, true },
 	{ NULL, 0, false }
 };
 


### PR DESCRIPTION
Add support for the Garmin fenix / quatix / tactix 8 devices that
support a dive computer mode up to 40m depth.

Fixes #108.
