### PR TITLE
Make MSVC Build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ Makefile.in
 /src/revision.h
 
 /build
+
+# Artifact produced by the Subsurface MSVC build
+/contrib/msvc/x64/


### PR DESCRIPTION
Fix build errors when compiling as C in MSVC.



Signed-off-by: Michael Keller [github@ike.ch](mailto:github@ike.ch)

