### PR TITLE
DiveSystem: Handle APOS5 sample record alias fix.

### DIFF
--- a/src/divesystem_idive_parser.c
+++ b/src/divesystem_idive_parser.c
@@ -60,7 +60,7 @@
 
 #define REC_SAMPLE 0
 #define REC_INFO   1
-#define REC_SAMPLE_APOS5_COMPAT 0x8006
+#define REC_SAMPLE_APOS5_COMPAT 0x8000
 
 typedef struct divesystem_idive_parser_t divesystem_idive_parser_t;
 
@@ -467,10 +467,10 @@ divesystem_idive_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callba
 		unsigned int type = ISIX3M(parser->model) ?
 			array_uint16_le (data + offset + 52) :
 			REC_SAMPLE;
-		// AI-generated (Claude)
-		// APOS5 uses 0x8006 for ordinary profile samples. Keep this alias
-		// narrow until the record type is confirmed by the vendor.
-		if (firmware_major >= 5 && type == REC_SAMPLE_APOS5_COMPAT)
+		// APOS5 firmware uses various record type values for ordinary
+		// profile samples (0x8006, 0x800E observed). The high bit 0x8000
+		// appears to flag sample records in APOS5.
+		if (firmware_major >= 5 && (type & REC_SAMPLE_APOS5_COMPAT))
 			type = REC_SAMPLE;
 		if (type != REC_SAMPLE) {
 			if (type == REC_INFO) {


### PR DESCRIPTION
Adressing https://github.com/libdivecomputer/libdivecomputer/issues/68

## Summary

Firmware **50211016** changed the **record type field** in sample records, causing libdivecomputer to skip all dive samples (treating them as non-sample metadata records). This results in **0m depth and 0min time** for every imported dive.

## Root Cause

The sample record type field at **byte offset 52** (a `uint16_le`) changed its value for ordinary profile samples:

| Firmware | Record Type Value | Interpreted As |
|---|---|---|
| 50206016 (old, works) | `0x0000` | `REC_SAMPLE` ✅ → parsed |
| 50211016 (new, broken) | `0x800E` | unknown → **skipped** ❌ |

### What happens in the code

In [divesystem_idive_parser.c]:

```c
// Get the record type.
unsigned int type = ISIX3M(parser->model) ?
    array_uint16_le (data + offset + 52) :
    REC_SAMPLE;

// APOS5 uses 0x8006 for ordinary profile samples.
if (firmware_major >= 5 && type == REC_SAMPLE_APOS5_COMPAT)  // 0x8006
    type = REC_SAMPLE;

if (type != REC_SAMPLE) {
    // Skip non-sample records.    ← ALL 0x800E samples end up here!
    offset += samplesize;
    continue;
}
```

A previous fix already mapped `0x8006` (`REC_SAMPLE_APOS5_COMPAT`) → `REC_SAMPLE` for APOS5 firmware. But firmware **50211016** now uses `0x800E` instead, which is **not handled**.

## Solution

Check only higher bit of the sample (0x80)