### PR TITLE
Shearwater: Map Perdix 3 hardware identifiers

### DIFF
--- a/src/shearwater_common.c
+++ b/src/shearwater_common.c
@@ -826,6 +826,10 @@ dc_status_t shearwater_common_get_model(shearwater_common_device_t *device, unsi
 	case 0xC964:
 		*model = PERDIX2;
 		break;
+	case 0x39C2:
+	case 0x4AB1:
+		*model = PERDIX3;
+		break;
 	case 0x1F0A:
 	case 0x0F0F:
 	case 0x1F10:
@@ -862,5 +866,4 @@ dc_status_t shearwater_common_get_model(shearwater_common_device_t *device, unsi
 
 	return status;
 }
-
 

--- a/src/shearwater_common.c
+++ b/src/shearwater_common.c
@@ -799,6 +799,8 @@ dc_status_t shearwater_common_get_model(shearwater_common_device_t *device, unsi
 		break;
 	case 0xB407:
 	case 0xB429:
+	case 0xB469:
+	case 0x3C3D:
 		*model = PETREL3;
 		break;
 	case 0x0606:
@@ -831,6 +833,7 @@ dc_status_t shearwater_common_get_model(shearwater_common_device_t *device, unsi
 		*model = PERDIX3;
 		break;
 	case 0x1F0A:
+	case 0x1F0F:
 	case 0x0F0F:
 	case 0x1F10:
 	case 0x1F1A:
@@ -866,4 +869,3 @@ dc_status_t shearwater_common_get_model(shearwater_common_device_t *device, unsi
 
 	return status;
 }
-


### PR DESCRIPTION
Map hardware identifiers 0x39C2 and 0x4AB1 to the existing PERDIX3 model so downloads report the correct device. Existing descriptor and protocol handling already support the model.
