### PR TITLE
shearwater: give Petrel 2 a distinct model number (15)

### DIFF
--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -381,7 +381,7 @@ static const dc_descriptor_t g_descriptors[] = {
 	{"Shearwater", "Predator", DC_FAMILY_SHEARWATER_PREDATOR, 2, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH, dc_filter_shearwater},
 	/* Shearwater Petrel */
 	{"Shearwater", "Petrel",    DC_FAMILY_SHEARWATER_PETREL, 3, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH, dc_filter_shearwater},
-	{"Shearwater", "Petrel 2",  DC_FAMILY_SHEARWATER_PETREL, 3, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_shearwater},
+	{"Shearwater", "Petrel 2",  DC_FAMILY_SHEARWATER_PETREL, 15, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_shearwater},
 	{"Shearwater", "Nerd",      DC_FAMILY_SHEARWATER_PETREL, 4, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH, dc_filter_shearwater},
 	{"Shearwater", "Perdix",    DC_FAMILY_SHEARWATER_PETREL, 5, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_shearwater},
 	{"Shearwater", "Perdix AI", DC_FAMILY_SHEARWATER_PETREL, 6, DC_TRANSPORT_BLE, dc_filter_shearwater},

--- a/src/shearwater_common.h
+++ b/src/shearwater_common.h
@@ -46,7 +46,6 @@ extern "C" {
 
 #define PREDATOR 2
 #define PETREL   3
-#define PETREL2  PETREL
 #define NERD     4
 #define PERDIX   5
 #define PERDIXAI 6
@@ -58,6 +57,7 @@ extern "C" {
 #define TERN     12
 #define PEREGRINE_TX 13
 #define PERDIX3  14
+#define PETREL2  15
 
 #define NSTEPS    10000
 #define STEP(i,n) ((NSTEPS * (i) + (n) / 2) / (n))


### PR DESCRIPTION
PETREL2 was aliased to PETREL (3), making it impossible to distinguish
a Shearwater Petrel 2 from a Petrel by model number alone.

Assign PETREL2 the distinct value 15 and update the 'Shearwater Petrel 2'
descriptor accordingly. PERDIX3 (14) was already present on Subsurface-DS9
from a prior merge; no change needed for that constant.

Hardware ID mappings in shearwater_common_get_model() are unchanged:
- 0x0404 / 0x0909 -> PETREL (3)
- 0x0505 / 0x0808 / 0x0838 / 0x08A5 / 0x0B0B / 0x7828 / 0x7B2C / 0x8838
  -> PETREL2 (now 15, previously aliased to 3)

shearwater_predator_parser.c defines its own local PREDATOR/PETREL/TERIC
constants and does not reference PETREL2; no change needed there.

Transport flags, protocol selection, parser behaviour, and all other
hardware-family boundaries are unchanged.
