### PR TITLE
field-cache: free cached strings when parser is destroyed

### DIFF
--- a/src/field-cache.c
+++ b/src/field-cache.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "platform.h"
@@ -118,4 +119,15 @@ dc_field_get(dc_field_cache_t *cache, dc_field_type_t type, unsigned int flags, 
 	}
 
 	return DC_STATUS_UNSUPPORTED;
+}
+
+void
+dc_field_cache_free (dc_field_cache_t *cache)
+{
+	for (unsigned int i = 0; i < MAXSTRINGS; i++) {
+		free ((char *) cache->strings[i].value);
+		cache->strings[i].value = NULL;
+		cache->strings[i].desc = NULL;
+	}
+	cache->initialized &= ~(1u << DC_FIELD_STRING);
 }

--- a/src/field-cache.h
+++ b/src/field-cache.h
@@ -39,6 +39,7 @@ dc_status_t dc_field_add_string(dc_field_cache_t *, const char *desc, const char
 dc_status_t dc_field_add_string_fmt(dc_field_cache_t *, const char *desc, const char *fmt, ...);
 dc_status_t dc_field_get_string(dc_field_cache_t *, unsigned idx, dc_field_string_t *value);
 dc_status_t dc_field_get(dc_field_cache_t *, dc_field_type_t, unsigned int, void *);
+void dc_field_cache_free (dc_field_cache_t *);
 
 /*
  * Macro to make it easy to set DC_FIELD_xyz values.

--- a/src/garmin_parser.c
+++ b/src/garmin_parser.c
@@ -366,6 +366,8 @@ garmin_parser_create (dc_parser_t **out, dc_context_t *context, const unsigned c
 		return DC_STATUS_NOMEMORY;
 	}
 
+	memset(&parser->cache, 0, sizeof(parser->cache));
+
 	garmin_parser_set_data(parser, data, size);
 
 	*out = (dc_parser_t *) parser;

--- a/src/garmin_parser.c
+++ b/src/garmin_parser.c
@@ -327,6 +327,7 @@ static dc_status_t garmin_parser_set_data (garmin_parser_t *garmin, const unsign
 static dc_status_t garmin_parser_get_datetime (dc_parser_t *abstract, dc_datetime_t *datetime);
 static dc_status_t garmin_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigned int flags, void *value);
 static dc_status_t garmin_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_t callback, void *userdata);
+static dc_status_t garmin_parser_destroy (dc_parser_t *abstract);
 
 static const dc_parser_vtable_t garmin_parser_vtable = {
 	sizeof(garmin_parser_t),
@@ -337,8 +338,18 @@ static const dc_parser_vtable_t garmin_parser_vtable = {
 	garmin_parser_get_datetime, /* datetime */
 	garmin_parser_get_field, /* fields */
 	garmin_parser_samples_foreach, /* samples_foreach */
-	NULL /* destroy */
+	garmin_parser_destroy /* destroy */
 };
+
+static dc_status_t
+garmin_parser_destroy (dc_parser_t *abstract)
+{
+	garmin_parser_t *garmin = (garmin_parser_t *) abstract;
+
+	dc_field_cache_free (&garmin->cache);
+
+	return DC_STATUS_SUCCESS;
+}
 
 dc_status_t
 garmin_parser_create (dc_parser_t **out, dc_context_t *context, const unsigned char data[], size_t size)

--- a/src/shearwater_predator_parser.c
+++ b/src/shearwater_predator_parser.c
@@ -279,6 +279,8 @@ shearwater_common_parser_create (dc_parser_t **out, dc_context_t *context, const
 		return DC_STATUS_NOMEMORY;
 	}
 
+	memset(&parser->cache, 0, sizeof(parser->cache));
+
 	// Set the default values.
 	parser->model = model;
 	parser->petrel = petrel;

--- a/src/shearwater_predator_parser.c
+++ b/src/shearwater_predator_parser.c
@@ -194,6 +194,7 @@ struct dc_parser_sensor_calibration_t {
 static dc_status_t shearwater_predator_parser_get_datetime (dc_parser_t *abstract, dc_datetime_t *datetime);
 static dc_status_t shearwater_predator_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigned int flags, void *value);
 static dc_status_t shearwater_predator_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_t callback, void *userdata);
+static dc_status_t shearwater_predator_parser_destroy (dc_parser_t *abstract);
 
 static dc_status_t shearwater_predator_parser_cache (shearwater_predator_parser_t *parser);
 
@@ -206,7 +207,7 @@ static const dc_parser_vtable_t shearwater_predator_parser_vtable = {
 	shearwater_predator_parser_get_datetime, /* datetime */
 	shearwater_predator_parser_get_field, /* fields */
 	shearwater_predator_parser_samples_foreach, /* samples_foreach */
-	NULL /* destroy */
+	shearwater_predator_parser_destroy /* destroy */
 };
 
 static const dc_parser_vtable_t shearwater_petrel_parser_vtable = {
@@ -218,7 +219,7 @@ static const dc_parser_vtable_t shearwater_petrel_parser_vtable = {
 	shearwater_predator_parser_get_datetime, /* datetime */
 	shearwater_predator_parser_get_field, /* fields */
 	shearwater_predator_parser_samples_foreach, /* samples_foreach */
-	NULL /* destroy */
+	shearwater_predator_parser_destroy /* destroy */
 };
 
 
@@ -239,6 +240,17 @@ shearwater_predator_find_gasmix (shearwater_predator_parser_t *parser, unsigned 
 	}
 
 	return i;
+}
+
+
+static dc_status_t
+shearwater_predator_parser_destroy (dc_parser_t *abstract)
+{
+	shearwater_predator_parser_t *parser = (shearwater_predator_parser_t *) abstract;
+
+	dc_field_cache_free (&parser->cache);
+
+	return DC_STATUS_SUCCESS;
 }
 
 
@@ -474,6 +486,7 @@ shearwater_predator_parser_cache (shearwater_predator_parser_t *parser)
 	if (parser->cached) {
 		return DC_STATUS_SUCCESS;
 	}
+	dc_field_cache_free (&parser->cache);
 	memset(&parser->cache, 0, sizeof(parser->cache));
 
 	// Log versions before 6 weren't reliably stored in the data, but

--- a/src/suunto_eonsteel_parser.c
+++ b/src/suunto_eonsteel_parser.c
@@ -1501,6 +1501,7 @@ suunto_eonsteel_parser_destroy(dc_parser_t *parser)
 {
 	suunto_eonsteel_parser_t *eon = (suunto_eonsteel_parser_t *) parser;
 
+	dc_field_cache_free (&eon->cache);
 	desc_free(eon->type_desc, MAXTYPE);
 
 	return DC_STATUS_SUCCESS;


### PR DESCRIPTION
dc_field_add_string() stores heap-allocated strings (via strdup) in
dc_field_cache_t.strings[].value. These were never freed when a parser
was destroyed, causing one leak per cached string field per parsed dive.

Add dc_field_cache_free() which iterates the strings array, frees each
value pointer, and clears the initialized bit for DC_FIELD_STRING.

Wire it into the destroy functions of the three parsers that embed a
dc_field_cache and populate string fields:

- shearwater_predator_parser.c: add destroy to both the Predator and
  Petrel vtables (shared implementation); also call it before the
  memset re-init in shearwater_predator_parser_cache() as a defensive
  measure against future re-caching.
- garmin_parser.c: add destroy to the garmin vtable.
- suunto_eonsteel_parser.c: add the cache free to the existing destroy
  alongside the existing desc_free call.
