### PR TITLE
DiveSystem: fix APOS5 record type detection for firmware 5.2.11+.

### DIFF
--- a/src/divesystem_idive_parser.c
+++ b/src/divesystem_idive_parser.c
@@ -60,6 +60,10 @@
 
 #define REC_INFO   1
 
+#define TANK_VALID        0x8000
+#define TANK_RFCHANNEL    0x001F
+#define TANK_PRESSURE_MSB 0x0020
+
 typedef struct divesystem_idive_parser_t divesystem_idive_parser_t;
 
 typedef struct divesystem_idive_gasmix_t {
@@ -579,6 +583,14 @@ divesystem_idive_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callba
 			unsigned int id = data[offset + 47] & 0x0F;
 			unsigned int flags = data[offset + 47] & 0xF0;
 			unsigned int pressure = data[offset + 49];
+			unsigned int DC_ATTR_UNUSED rfchannel = 0;
+
+			if (type & TANK_VALID) {
+				rfchannel = type & TANK_RFCHANNEL;
+				if (type & TANK_PRESSURE_MSB) {
+					pressure |= 0x100;
+				}
+			}
 
 			if (flags & 0x20) {
 				// 300 bar transmitter.

--- a/src/divesystem_idive_parser.c
+++ b/src/divesystem_idive_parser.c
@@ -58,9 +58,7 @@
 #define IX3M2_ZHL16C   2
 #define IX3M2_VPM      3
 
-#define REC_SAMPLE 0
 #define REC_INFO   1
-#define REC_SAMPLE_APOS5_COMPAT 0x8006
 
 typedef struct divesystem_idive_parser_t divesystem_idive_parser_t;
 
@@ -450,19 +448,12 @@ divesystem_idive_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callba
 		// Get the record type.
 		unsigned int type = ISIX3M(parser->model) ?
 			array_uint16_le (data + offset + 52) :
-			REC_SAMPLE;
-		// AI-generated (Claude)
-		// APOS5 uses 0x8006 for ordinary profile samples. Keep this alias
-		// narrow until the record type is confirmed by the vendor.
-		if (firmware_major >= 5 && type == REC_SAMPLE_APOS5_COMPAT)
-			type = REC_SAMPLE;
-		if (type != REC_SAMPLE) {
-			if (type == REC_INFO) {
-				altitude  = (signed int) array_uint32_le (data + offset + 40);
-				longitude = (signed int) array_uint32_le (data + offset + 44);
-				latitude  = (signed int) array_uint32_le (data + offset + 48);
-				have_location = 1;
-			}
+			0;
+		if (type == REC_INFO) {
+			altitude  = (signed int) array_uint32_le (data + offset + 40);
+			longitude = (signed int) array_uint32_le (data + offset + 44);
+			latitude  = (signed int) array_uint32_le (data + offset + 48);
+			have_location = 1;
 
 			// Skip non-sample records.
 			offset += samplesize;


### PR DESCRIPTION
Cherry-picks two commits from jefdriesen's upstream libdivecomputer that fix dive import from Ratio iX3M devices running APOS5 firmware 5.2.11 or later, where all dives were imported with 0 m depth and 0 minutes duration.
Root cause: since firmware 5.2.11 the record type field is no longer a simple type byte. The higher bits are reused to carry tank-related information, so sample records no longer have type 0. The previous code checked type == REC_SAMPLE (0) and skipped everything else, producing empty profiles.
Fix: instead of checking for a known sample type, only treat type == REC_INFO (1) as a non-sample record. Everything else is parsed as a normal sample, regardless of what the higher bits contain. The second commit then actually interprets those higher bits to recover the extra pressure MSB for 300-bar tanks and the RF channel.
This supersedes the earlier workaround on this branch that aliased 0x8006 to REC_SAMPLE.
Fixes subsurface/subsurface#4961. Related: libdivecomputer/libdivecomputer#66, libdivecomputer/libdivecomputer#68.
