### PR TITLE
halcyon_symbios: treat timeout as retryable and raise BLE read timeout to 5 s

### DIFF
--- a/src/halcyon_symbios.c
+++ b/src/halcyon_symbios.c
@@ -307,6 +307,15 @@ halcyon_symbios_download (halcyon_symbios_device_t *device, dc_event_progress_t 
 				goto error_exit;
 			}
 
+			// If the error was a timeout, the packet may have arrived
+			// late and be sitting in the receive queue.  Flush it before
+			// requesting a re-transmission to avoid reading the stale
+			// copy instead of the retransmitted block.
+			if (status == DC_STATUS_TIMEOUT) {
+				dc_iostream_sleep (device->iostream, 300);
+				dc_iostream_purge (device->iostream, DC_DIRECTION_INPUT);
+			}
+
 			// Send a NAK to request a re-transmission.
 			status = halcyon_symbios_send (device, NAK, NULL, 0);
 			if (status != DC_STATUS_SUCCESS) {

--- a/src/halcyon_symbios.c
+++ b/src/halcyon_symbios.c
@@ -296,7 +296,7 @@ halcyon_symbios_download (halcyon_symbios_device_t *device, dc_event_progress_t 
 		unsigned int nretries = 0;
 		while ((status = halcyon_symbios_recv (device, block, payload, sizeof(payload), &len, NULL)) != DC_STATUS_SUCCESS) {
 			// Abort if the error is fatal.
-			if (status != DC_STATUS_PROTOCOL) {
+			if (status != DC_STATUS_PROTOCOL && status != DC_STATUS_TIMEOUT) {
 				ERROR (abstract->context, "Failed to receive the answer.");
 				goto error_exit;
 			}
@@ -396,8 +396,8 @@ halcyon_symbios_device_open (dc_device_t **out, dc_context_t *context, dc_iostre
 	device->iostream = iostream;
 	memset(device->fingerprint, 0, sizeof(device->fingerprint));
 
-	// Set the timeout for receiving data (3000ms).
-	status = dc_iostream_set_timeout (device->iostream, 3000);
+	// Set the timeout for receiving data (5000ms).
+	status = dc_iostream_set_timeout (device->iostream, 5000);
 	if (status != DC_STATUS_SUCCESS) {
 		ERROR (context, "Failed to set the timeout.");
 		goto error_free;

--- a/src/halcyon_symbios.c
+++ b/src/halcyon_symbios.c
@@ -312,8 +312,10 @@ halcyon_symbios_download (halcyon_symbios_device_t *device, dc_event_progress_t 
 			// requesting a re-transmission to avoid reading the stale
 			// copy instead of the retransmitted block.
 			if (status == DC_STATUS_TIMEOUT) {
-				status = dc_iostream_sleep (device->iostream, 300);
-				if (status != DC_STATUS_SUCCESS) {
+				// AI-generated (Claude)
+				// Poll processes transport events while waiting for late data.
+				status = dc_iostream_poll (device->iostream, 300);
+				if (status != DC_STATUS_SUCCESS && status != DC_STATUS_TIMEOUT) {
 					ERROR (abstract->context, "Failed to wait for late data.");
 					goto error_exit;
 				}

--- a/src/halcyon_symbios.c
+++ b/src/halcyon_symbios.c
@@ -312,8 +312,17 @@ halcyon_symbios_download (halcyon_symbios_device_t *device, dc_event_progress_t 
 			// requesting a re-transmission to avoid reading the stale
 			// copy instead of the retransmitted block.
 			if (status == DC_STATUS_TIMEOUT) {
-				dc_iostream_sleep (device->iostream, 300);
-				dc_iostream_purge (device->iostream, DC_DIRECTION_INPUT);
+				status = dc_iostream_sleep (device->iostream, 300);
+				if (status != DC_STATUS_SUCCESS) {
+					ERROR (abstract->context, "Failed to wait for late data.");
+					goto error_exit;
+				}
+
+				status = dc_iostream_purge (device->iostream, DC_DIRECTION_INPUT);
+				if (status != DC_STATUS_SUCCESS) {
+					ERROR (abstract->context, "Failed to purge late data.");
+					goto error_exit;
+				}
 			}
 
 			// Send a NAK to request a re-transmission.


### PR DESCRIPTION
The user-supplied log shows a ~3 s gap in BLE notifications mid-transfer
that triggers the read timeout.  The most likely cause on iOS is a
transient suspension of BLE notifications (for example during connection
parameter renegotiation), though the exact mechanism is inferred from the
log pattern rather than confirmed.

With the previous code a single DC_STATUS_TIMEOUT in the inner retry loop
of halcyon_symbios_download() was treated as a fatal error and caused an
immediate abort, even though up to MAXRETRIES (3) retries were available
for protocol errors.

Three fixes across two commits:

1. Include DC_STATUS_TIMEOUT in the retryable-error condition (alongside
   DC_STATUS_PROTOCOL) so that a transient notification gap triggers a
   NAK re-transmission instead of aborting the download.  This matches
   the pattern used by suunto_common2, divesystem_idive, hw_ostc,
   mares_common, oceanic_vtpro, and other drivers.  The existing
   MAXRETRIES limit is still enforced; a persistent timeout still
   terminates the transfer.

2. Raise the BLE read timeout from 3000 ms to 5000 ms in
   halcyon_symbios_device_open().  The 3 s value is tight for iOS BLE;
   other drivers in the same codebase use 4000-5000 ms, giving the
   stack more headroom before a timeout fires.

3. Before sending the NAK on a timeout, sleep 300 ms and purge the
   input queue.  If a packet arrived marginally late it may already be
   queued; without the purge the driver would read the stale copy and
   the retransmitted block would corrupt the next read.

Fixes subsurface/subsurface#4929