### PR TITLE
Add Cressi Raffaello (model 6) to the Goa family

### DIFF
--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -367,6 +367,7 @@ static const dc_descriptor_t g_descriptors[] = {
 	{"Cressi", "Leonardo 2.0", DC_FAMILY_CRESSI_GOA, 3, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
 	{"Cressi", "Donatello",    DC_FAMILY_CRESSI_GOA, 4, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
 	{"Cressi", "Michelangelo", DC_FAMILY_CRESSI_GOA, 5, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
+	{"Cressi", "Raffaello",     DC_FAMILY_CRESSI_GOA, 6, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
 	{"Cressi", "Neon",     DC_FAMILY_CRESSI_GOA, 9, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
 	{"Cressi", "Nepto",    DC_FAMILY_CRESSI_GOA, 10, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_cressi},
 	/* Zeagle N2iTiON3 */
@@ -961,6 +962,7 @@ dc_filter_cressi (const dc_descriptor_t *descriptor, dc_transport_t transport, c
 		3,  // Leonardo 2.0
 		4,  // Donatello
 		5,  // Michelangelo
+		6,  // Raffaello
 		9,  // Neon
 		10, // Nepto
 	};


### PR DESCRIPTION
The Raffaello identifies itself as model 6 via the CMD_VERSION response.
It is fully compatible with the existing Goa BLE protocol and parser;
firmware 3.09 maps to format version 5 via the existing firmware-range
logic.

Add a descriptor entry and include model 6 in the BLE filter so the
Raffaello can be selected directly by name and auto-detected via its
'6_<hex>' BLE advertisement prefix.
