### PR TITLE
field-cache: define string ownership

### DIFF
--- a/examples/output_xml.c
+++ b/examples/output_xml.c
@@ -500,6 +500,7 @@ dctool_xml_output_write (dctool_output_t *abstract, dc_parser_t *parser, const u
 			break;
 		fprintf (output->ostream, "<extradata key='%s' value='%s' />\n",
 			str.desc, str.value);
+		free ((void *) str.value);
 	}
 
 	// Parse the GPS location.

--- a/include/libdivecomputer/parser.h
+++ b/include/libdivecomputer/parser.h
@@ -362,6 +362,7 @@ dc_parser_set_density (dc_parser_t *parser, double density);
 dc_status_t
 dc_parser_get_datetime (dc_parser_t *parser, dc_datetime_t *datetime);
 
+/* DC_FIELD_STRING values are caller-owned and must be freed after use. */
 dc_status_t
 dc_parser_get_field (dc_parser_t *parser, dc_field_type_t type, unsigned int flags, void *value);
 

--- a/src/field-cache.c
+++ b/src/field-cache.c
@@ -58,11 +58,25 @@ dc_status_t dc_field_get_string(dc_field_cache_t *cache, unsigned idx, dc_field_
 	if (idx < MAXSTRINGS) {
 		dc_field_string_t *res = cache->strings+idx;
 		if (res->desc && res->value) {
-			*value = *res;
+			value->desc = res->desc;
+			value->value = strdup(res->value);
+			if (!value->value)
+				return DC_STATUS_NOMEMORY;
 			return DC_STATUS_SUCCESS;
 		}
 	}
 	return DC_STATUS_UNSUPPORTED;
+}
+
+void
+dc_field_cache_free (dc_field_cache_t *cache)
+{
+	for (unsigned int i = 0; i < MAXSTRINGS; i++) {
+		free ((char *) cache->strings[i].value);
+		cache->strings[i].value = NULL;
+		cache->strings[i].desc = NULL;
+	}
+	cache->initialized &= ~(1u << DC_FIELD_STRING);
 }
 
 
@@ -119,15 +133,4 @@ dc_field_get(dc_field_cache_t *cache, dc_field_type_t type, unsigned int flags, 
 	}
 
 	return DC_STATUS_UNSUPPORTED;
-}
-
-void
-dc_field_cache_free (dc_field_cache_t *cache)
-{
-	for (unsigned int i = 0; i < MAXSTRINGS; i++) {
-		free ((char *) cache->strings[i].value);
-		cache->strings[i].value = NULL;
-		cache->strings[i].desc = NULL;
-	}
-	cache->initialized &= ~(1u << DC_FIELD_STRING);
 }


### PR DESCRIPTION
DC_FIELD_STRING callers have long owned the returned value, but the field cache returned an alias of its own allocation. Freeing cached strings during parser destruction consequently double-freed values already released by consumers.

Return a duplicate to callers, free cache-owned originals when cache-backed parsers are reset or destroyed, and release strings in dctool after writing them. Document the caller-owned API contract.

Fixes a crash introduced in #130.
