### PR TITLE
libdivecomputer: Preserve Heinrichs Weikamp product refinement

### DIFF
--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -127,6 +127,9 @@ static const dc_hw_id_entry_t g_hw_id_map[] = {
 	{DC_FAMILY_SHEARWATER_PETREL, 3, 0x7828, "Petrel 2"},
 	{DC_FAMILY_SHEARWATER_PETREL, 3, 0x7B2C, "Petrel 2"},
 	{DC_FAMILY_SHEARWATER_PETREL, 3, 0x8838, "Petrel 2"},
+	/* HW OSTC3: only OSTC 4 and OSTC 5 hardware descriptors are unique. */
+	{DC_FAMILY_HW_OSTC3, 0x43, 0x3B43, "OSTC 4"},
+	{DC_FAMILY_HW_OSTC3, 0x44, 0x3B44, "OSTC 5"},
 };
 
 static const dc_descriptor_t g_descriptors[] = {
@@ -363,22 +366,15 @@ static const dc_descriptor_t g_descriptors[] = {
 	{"Mares", "Puck Pro EZ",       DC_FAMILY_MARES_ICONHD , 0x35, DC_TRANSPORT_BLE, dc_filter_mares},
 	{"Mares", "Puck Pro Ultra",    DC_FAMILY_MARES_ICONHD , 0x35, DC_TRANSPORT_BLE, dc_filter_mares},
 	/* Heinrichs Weikamp */
-	/* Current models */
-	{"Heinrichs Weikamp", "OSTC Nano",  DC_FAMILY_HW_OSTC3, 0x11, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_hw},
-	{"Heinrichs Weikamp", "OSTC 5",     DC_FAMILY_HW_OSTC3, 0x3B44, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
-	{"Heinrichs Weikamp", "OSTC Plus",  DC_FAMILY_HW_OSTC3, 0x13, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
-	{"Heinrichs Weikamp", "OSTC Plus",  DC_FAMILY_HW_OSTC3, 0x1A, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
-	{"Heinrichs Weikamp", "OSTC 2",     DC_FAMILY_HW_OSTC3, 0x11, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
-	{"Heinrichs Weikamp", "OSTC 2",     DC_FAMILY_HW_OSTC3, 0x13, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
-	{"Heinrichs Weikamp", "OSTC 2",     DC_FAMILY_HW_OSTC3, 0x1B, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
-	/* Historic models */
-	{"Heinrichs Weikamp", "OSTC 4",     DC_FAMILY_HW_OSTC3, 0x3B43, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
-	{"Heinrichs Weikamp", "OSTC cR",    DC_FAMILY_HW_OSTC3, 0x05, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
-	{"Heinrichs Weikamp", "OSTC cR",    DC_FAMILY_HW_OSTC3, 0x07, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
-	{"Heinrichs Weikamp", "OSTC Sport", DC_FAMILY_HW_OSTC3, 0x12, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
-	{"Heinrichs Weikamp", "OSTC Sport", DC_FAMILY_HW_OSTC3, 0x13, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
-	{"Heinrichs Weikamp", "OSTC 2 TR",  DC_FAMILY_HW_OSTC3, 0x33, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
-	{"Heinrichs Weikamp", "OSTC 3",     DC_FAMILY_HW_OSTC3, 0x0A, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
+	{"Heinrichs Weikamp", "OSTC 2",     DC_FAMILY_HW_OSTC3, 0, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
+	{"Heinrichs Weikamp", "OSTC 2 TR",  DC_FAMILY_HW_OSTC3, 0, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
+	{"Heinrichs Weikamp", "OSTC 3",     DC_FAMILY_HW_OSTC3, 0, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
+	{"Heinrichs Weikamp", "OSTC cR",    DC_FAMILY_HW_OSTC3, 0, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
+	{"Heinrichs Weikamp", "OSTC Plus",  DC_FAMILY_HW_OSTC3, 0, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
+	{"Heinrichs Weikamp", "OSTC Sport", DC_FAMILY_HW_OSTC3, 0, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
+	{"Heinrichs Weikamp", "OSTC Nano",  DC_FAMILY_HW_OSTC3, 0, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLE, dc_filter_hw},
+	{"Heinrichs Weikamp", "OSTC 4",     DC_FAMILY_HW_OSTC3, 0x43, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
+	{"Heinrichs Weikamp", "OSTC 5",     DC_FAMILY_HW_OSTC3, 0x44, DC_TRANSPORT_SERIAL | DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE, dc_filter_hw},
 	{"Heinrichs Weikamp", "OSTC 2N",  DC_FAMILY_HW_OSTC, 2, DC_TRANSPORT_SERIAL, NULL},
 	{"Heinrichs Weikamp", "OSTC 2C",  DC_FAMILY_HW_OSTC, 3, DC_TRANSPORT_SERIAL, NULL},
 	{"Heinrichs Weikamp", "OSTC Mk2", DC_FAMILY_HW_OSTC, 1, DC_TRANSPORT_SERIAL, NULL},

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -127,7 +127,18 @@ static const dc_hw_id_entry_t g_hw_id_map[] = {
 	{DC_FAMILY_SHEARWATER_PETREL, 3, 0x7828, "Petrel 2"},
 	{DC_FAMILY_SHEARWATER_PETREL, 3, 0x7B2C, "Petrel 2"},
 	{DC_FAMILY_SHEARWATER_PETREL, 3, 0x8838, "Petrel 2"},
-	/* HW OSTC3: only OSTC 4 and OSTC 5 hardware descriptors are unique. */
+	/* HW OSTC3: preserve the descriptor resolution used before model IDs
+	 * followed the protocol semantics. Duplicate legacy IDs retain the first
+	 * matching descriptor from the former table. */
+	{DC_FAMILY_HW_OSTC3, 0,    0x11,   "OSTC Nano"},
+	{DC_FAMILY_HW_OSTC3, 0,    0x13,   "OSTC Plus"},
+	{DC_FAMILY_HW_OSTC3, 0,    0x1A,   "OSTC Plus"},
+	{DC_FAMILY_HW_OSTC3, 0,    0x1B,   "OSTC 2"},
+	{DC_FAMILY_HW_OSTC3, 0,    0x05,   "OSTC cR"},
+	{DC_FAMILY_HW_OSTC3, 0,    0x07,   "OSTC cR"},
+	{DC_FAMILY_HW_OSTC3, 0,    0x12,   "OSTC Sport"},
+	{DC_FAMILY_HW_OSTC3, 0,    0x33,   "OSTC 2 TR"},
+	{DC_FAMILY_HW_OSTC3, 0,    0x0A,   "OSTC 3"},
 	{DC_FAMILY_HW_OSTC3, 0x43, 0x3B43, "OSTC 4"},
 	{DC_FAMILY_HW_OSTC3, 0x44, 0x3B44, "OSTC 5"},
 };

--- a/src/hw_ostc3.c
+++ b/src/hw_ostc3.c
@@ -700,11 +700,12 @@ hw_ostc3_device_init (hw_ostc3_device_t *device, hw_ostc3_state_t state)
 		device->hardware = hardware_prefix;
 		device->feature = array_uint16_be(hardware2 + 2);
 		device->firmware = array_uint16_be (version + 2);
+		device->model = 0;
 	} else {
 		device->hardware = (hardware_prefix << 8) | hardware2[4];
 		device->firmware = array_uint16_le (version + 2);
+		device->model = hardware2[4];
 	}
-	device->model = hardware2[4];
 	device->serial = array_uint16_le (version + 0);
 
 	DEBUG (abstract->context, "Device: hardware=%04x, feature=%04x, model=%02x",
@@ -818,8 +819,9 @@ hw_ostc3_device_hardware (dc_device_t *abstract, unsigned char data[], unsigned 
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 
-	// Send the command.
-	rc = hw_ostc3_device_id (device, data, size);
+	// Send the requested command without synthesising a HARDWARE2 reply.
+	const unsigned char cmd = size == SZ_HARDWARE2 ? HARDWARE2 : HARDWARE;
+	rc = hw_ostc3_transfer (device, NULL, cmd, NULL, 0, data, size, NULL, NODELAY);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 
@@ -843,17 +845,10 @@ hw_ostc3_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, voi
 
 	// Emit a device info event.
 	dc_event_devinfo_t devinfo;
+	device_set_hw_id (abstract, device->hardware);
 	devinfo.firmware = device->firmware;
 	devinfo.serial = device->serial;
-	if (device->hardware != UNKNOWN) {
-		devinfo.model = device->hardware;
-	} else {
-		// Fallback to the serial number.
-		if (devinfo.serial > 10000)
-			devinfo.model = SPORT;
-		else
-			devinfo.model = OSTC3;
-	}
+	devinfo.model = device->model;
 	device_event_emit (abstract, DC_EVENT_DEVINFO, &devinfo);
 
 	// Allocate memory.
@@ -1883,17 +1878,10 @@ hw_ostc3_device_dump (dc_device_t *abstract, dc_buffer_t *buffer)
 
 	// Emit a device info event.
 	dc_event_devinfo_t devinfo;
+	device_set_hw_id (abstract, device->hardware);
 	devinfo.firmware = device->firmware;
 	devinfo.serial = device->serial;
-	if (device->hardware != UNKNOWN) {
-		devinfo.model = device->hardware;
-	} else {
-		// Fallback to the serial number.
-		if (devinfo.serial > 10000)
-			devinfo.model = SPORT;
-		else
-			devinfo.model = OSTC3;
-	}
+	devinfo.model = device->model;
 	device_event_emit (abstract, DC_EVENT_DEVINFO, &devinfo);
 
 	// Allocate the required amount of memory.


### PR DESCRIPTION
Restore upstream hwOS device-info model semantics while retaining the existing Heinrichs Weikamp product resolution through the generic hardware-ID refinement path.

- Report model `0` for legacy hwOS devices, with `0x43` and `0x44` for OSTC 4 and OSTC 5.
- Use the raw hardware descriptor to refine recognised product labels, including legacy models.
- Return an unsupported error for unavailable five-byte `HARDWARE2` requests.
- Preserve OSTCTools imported-device labels separately from parser model selection.
- Add OSTCTools import coverage for the supplied legacy fixtures.

## Testing

- Focused `dc_descriptor_find_by_hw_id()` lookup test covering 11 Heinrichs Weikamp hardware IDs.
- `ctest --output-on-failure` (34/34 passed).
